### PR TITLE
Implement tenant ID discovery and credential caching for Azure Blob Storage

### DIFF
--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"log/slog"
 	"math"
+	"net/http"
 	"net/url"
 	"os"
 	"path"
@@ -41,6 +42,10 @@ var (
 
 	// Per-account blob client cache (thread-safe via sync.Map).
 	blobClientCache sync.Map // map[string]*azblob.Client
+
+	// Per-tenant credential cache (thread-safe via sync.Map).
+	tenantCredCache    sync.Map // map[string]azcore.TokenCredential
+	tenantCredInflight sync.Map // map[string]*sync.Mutex — serializes credential acquisition per tenant
 )
 
 // MkContainer creates a new Azure Blob container
@@ -388,11 +393,182 @@ func processHierarchySegment(seg *container.BlobHierarchyListSegment, prefix str
 	return nil
 }
 
+// accountTenantID returns the tenant ID for a storage account. It first
+// checks the BBB_AZ_TENANT_<ACCOUNT> environment variable, then falls back
+// to auto-discovery by probing the storage endpoint's WWW-Authenticate header.
+func accountTenantID(account string) string {
+	if tid := os.Getenv("BBB_AZ_TENANT_" + strings.ToUpper(account)); tid != "" {
+		return tid
+	}
+	if tid := os.Getenv("BBB_AZ_TENANT_" + account); tid != "" {
+		return tid
+	}
+	return discoverTenantID(account)
+}
+
+// tenantCache caches discovered tenant IDs per storage account.
+var tenantCache sync.Map // map[string]string
+
+// discoverTenantID makes an unauthenticated request to the storage account
+// endpoint and extracts the tenant ID from the WWW-Authenticate challenge
+// header. Returns "" if discovery fails.
+func discoverTenantID(account string) string {
+	if cached, ok := tenantCache.Load(account); ok {
+		return cached.(string)
+	}
+	endpoint := getEndpoint(account) + "/?comp=list&restype=container"
+	slog.Debug("tenant discovery: probing endpoint", "account", account, "url", endpoint)
+	req, err := http.NewRequest("GET", endpoint, nil)
+	if err != nil {
+		slog.Debug("tenant discovery: request creation failed", "account", account, "error", err)
+		return ""
+	}
+	req.Header.Set("x-ms-version", "2020-08-04")
+	resp, err := defaultHTTPClient().Do(req)
+	if err != nil {
+		slog.Debug("tenant discovery: HEAD failed", "account", account, "error", err)
+		return ""
+	}
+	resp.Body.Close()
+
+	// WWW-Authenticate: Bearer authorization_uri=https://login.microsoftonline.com/<tenant-id>/oauth2/authorize ...
+	auth := resp.Header.Get("Www-Authenticate")
+	slog.Debug("tenant discovery: response", "account", account, "status", resp.StatusCode, "www-authenticate", auth)
+	tid := parseTenantFromChallenge(auth)
+	if tid != "" {
+		slog.Debug("Discovered tenant for storage account", "account", account, "tenant", tid)
+		tenantCache.Store(account, tid)
+	}
+	return tid
+}
+
+// challengeTenantRe extracts the tenant GUID from the authorization_uri in a
+// WWW-Authenticate: Bearer challenge response.
+var challengeTenantRe = regexp.MustCompile(`authorization_uri="?https://login\.microsoftonline\.com/([0-9a-f-]{36})/`)
+
+func parseTenantFromChallenge(header string) string {
+	m := challengeTenantRe.FindStringSubmatch(header)
+	if len(m) < 2 {
+		return ""
+	}
+	return m[1]
+}
+
+var defaultHTTPClientOnce sync.Once
+var defaultHTTPClientVal *http.Client
+
+func defaultHTTPClient() *http.Client {
+	defaultHTTPClientOnce.Do(func() {
+		defaultHTTPClientVal = &http.Client{Timeout: 10 * time.Second}
+	})
+	return defaultHTTPClientVal
+}
+
+// PreAuthenticate eagerly authenticates to the given storage accounts
+// sequentially. This ensures any interactive login popups happen one at a
+// time before parallel workers start. It also pre-warms the blob client
+// and UDK caches so that no credential acquisition happens during copy.
+func PreAuthenticate(ctx context.Context, accounts ...string) error {
+	for _, account := range accounts {
+		// Trigger tenant discovery + credential acquisition.
+		_, err := getAzBlobClient(ctx, account)
+		if err != nil {
+			return fmt.Errorf("pre-authenticate %s: %w", account, err)
+		}
+		// Pre-warm the UDK cache so SAS generation doesn't trigger
+		// a second credential acquisition later.
+		_, _, _, _, err = getUDC(ctx, account)
+		if err != nil {
+			slog.Debug("pre-authenticate: UDK warm-up failed (non-fatal)", "account", account, "error", err)
+		}
+	}
+	return nil
+}
+
+// getCredentialForAccount returns a TokenCredential appropriate for the given
+// storage account. The tenant is auto-discovered from the storage endpoint's
+// challenge header (or overridden via BBB_AZ_TENANT_<ACCOUNT> env var).
+// When a tenant is found, it tries AzureCLICredential first, then falls back
+// to InteractiveBrowserCredential (popup login).
+//
+// Only one browser popup is opened per tenant; concurrent callers wait for
+// the first to complete.
+func getCredentialForAccount(account string) (azcore.TokenCredential, error) {
+	tid := accountTenantID(account)
+	if tid == "" {
+		return getDefaultCredential()
+	}
+	slog.Debug("Using tenant-specific credential", "account", account, "tenant", tid)
+
+	// Return cached credential for this tenant if available.
+	if cached, ok := tenantCredCache.Load(tid); ok {
+		return cached.(azcore.TokenCredential), nil
+	}
+
+	// Serialize credential acquisition per tenant so only one browser
+	// popup is shown, even when multiple goroutines race.
+	inflightVal, _ := tenantCredInflight.LoadOrStore(tid, &sync.Mutex{})
+	mu := inflightVal.(*sync.Mutex)
+	mu.Lock()
+	defer mu.Unlock()
+
+	// Double-check cache after acquiring the lock.
+	if cached, ok := tenantCredCache.Load(tid); ok {
+		return cached.(azcore.TokenCredential), nil
+	}
+
+	// Try AzureCLICredential first — works if the user has `az login`'d
+	// to this tenant. If GetToken fails, fall back to interactive browser.
+	cliCred, err := azidentity.NewAzureCLICredential(&azidentity.AzureCLICredentialOptions{
+		TenantID: tid,
+	})
+	if err == nil {
+		// Test if CLI credential actually works for this tenant.
+		_, tokenErr := cliCred.GetToken(context.Background(), policy.TokenRequestOptions{
+			Scopes: []string{"https://storage.azure.com/.default"},
+		})
+		if tokenErr == nil {
+			slog.Debug("Using AzureCLICredential for tenant", "tenant", tid)
+			tenantCredCache.Store(tid, cliCred)
+			return cliCred, nil
+		}
+		slog.Debug("AzureCLICredential failed for tenant, falling back to interactive login",
+			"tenant", tid, "error", tokenErr)
+	}
+
+	// Fall back to interactive browser login for the discovered tenant.
+	slog.Info("CLI credential failed for tenant, opening browser login", "account", account, "tenant", tid)
+	fmt.Fprintf(os.Stderr, "\n  Storage account %q requires authentication to tenant %s.\n  Opening browser...\n", account, tid)
+	browserCred, err := azidentity.NewInteractiveBrowserCredential(&azidentity.InteractiveBrowserCredentialOptions{
+		TenantID: tid,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("interactive credential for tenant %s: %w", tid, err)
+	}
+
+	// Eagerly acquire a CAE-capable token to trigger the browser popup now,
+	// before any parallel goroutines need the credential. EnableCAE ensures
+	// the cached token includes the CP1 claims that the SDK pipeline will
+	// request later, preventing a second browser popup.
+	_, err = browserCred.GetToken(context.Background(), policy.TokenRequestOptions{
+		Scopes:    []string{"https://storage.azure.com/.default"},
+		EnableCAE: true,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("interactive login for tenant %s: %w", tid, err)
+	}
+
+	tenantCredCache.Store(tid, browserCred)
+	return browserCred, nil
+}
+
 // getDefaultCredential returns a process-wide cached DefaultAzureCredential.
 // The credential is thread-safe and handles token refresh internally.
 func getDefaultCredential() (*azidentity.DefaultAzureCredential, error) {
 	cachedDefaultCredOnce.Do(func() {
-		cachedDefaultCred, cachedDefaultCredErr = azidentity.NewDefaultAzureCredential(nil)
+		cachedDefaultCred, cachedDefaultCredErr = azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
+			AdditionallyAllowedTenants: []string{"*"},
+		})
 		if cachedDefaultCredErr == nil && slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 			tok, tokErr := cachedDefaultCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{"https://storage.azure.com/.default"}})
 			if tokErr == nil {
@@ -435,7 +611,7 @@ func getAzBlobClient(ctx context.Context, account string) (*azblob.Client, error
 			return nil, err
 		}
 	} else {
-		cred, credErr := getDefaultCredential()
+		cred, credErr := getCredentialForAccount(account)
 		if credErr != nil {
 			return nil, credErr
 		}
@@ -714,7 +890,7 @@ func readerSize(reader io.Reader) int64 {
 }
 
 // UploadStream writes blob content from a reader (overwrite).
-func UploadStream(ctx context.Context, ap AzurePath, reader io.Reader) error {
+func UploadStream(ctx context.Context, ap AzurePath, reader io.Reader, concurrency int) error {
 	if ap.Blob == "" || strings.HasSuffix(ap.Blob, "/") {
 		return errors.New("cannot upload to directory-like path")
 	}
@@ -732,8 +908,12 @@ func UploadStream(ctx context.Context, ap AzurePath, reader io.Reader) error {
 			return fmt.Errorf("put failed: stream size %d exceeds %d", size, maxSize)
 		}
 	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
 	_, err = blobClient.UploadStream(ctx, reader, &azblob.UploadStreamOptions{
-		BlockSize: blockSize,
+		BlockSize:   blockSize,
+		Concurrency: concurrency,
 	})
 	if err != nil {
 		return fmt.Errorf("put failed: %v", err)
@@ -1069,9 +1249,9 @@ func getUDC(ctx context.Context, account string) (*service.UserDelegationCredent
 // refreshUDC performs the actual UDC refresh (network call). Called at most
 // once per account at a time, guarded by udcInflight.
 func refreshUDC(ctx context.Context, account string) (*service.UserDelegationCredential, *service.Client, time.Time, time.Time, error) {
-	cred, err := getDefaultCredential()
+	cred, err := getCredentialForAccount(account)
 	if err != nil {
-		return nil, nil, time.Time{}, time.Time{}, fmt.Errorf("default credential: %w", err)
+		return nil, nil, time.Time{}, time.Time{}, fmt.Errorf("credential for %s: %w", account, err)
 	}
 	endpoint := getEndpoint(account)
 	svcClient, err := service.NewClient(endpoint, cred, nil)

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -396,14 +396,14 @@ func processHierarchySegment(seg *container.BlobHierarchyListSegment, prefix str
 // accountTenantID returns the tenant ID for a storage account. It first
 // checks the BBB_AZ_TENANT_<ACCOUNT> environment variable, then falls back
 // to auto-discovery by probing the storage endpoint's WWW-Authenticate header.
-func accountTenantID(account string) string {
+func accountTenantID(ctx context.Context, account string) string {
 	if tid := os.Getenv("BBB_AZ_TENANT_" + strings.ToUpper(account)); tid != "" {
 		return tid
 	}
 	if tid := os.Getenv("BBB_AZ_TENANT_" + account); tid != "" {
 		return tid
 	}
-	return discoverTenantID(account)
+	return discoverTenantID(ctx, account)
 }
 
 // tenantCache caches discovered tenant IDs per storage account.
@@ -412,13 +412,13 @@ var tenantCache sync.Map // map[string]string
 // discoverTenantID makes an unauthenticated request to the storage account
 // endpoint and extracts the tenant ID from the WWW-Authenticate challenge
 // header. Returns "" if discovery fails.
-func discoverTenantID(account string) string {
+func discoverTenantID(ctx context.Context, account string) string {
 	if cached, ok := tenantCache.Load(account); ok {
 		return cached.(string)
 	}
 	endpoint := getEndpoint(account) + "/?comp=list&restype=container"
 	slog.Debug("tenant discovery: probing endpoint", "account", account, "url", endpoint)
-	req, err := http.NewRequest("GET", endpoint, nil)
+	req, err := http.NewRequestWithContext(ctx, "GET", endpoint, nil)
 	if err != nil {
 		slog.Debug("tenant discovery: request creation failed", "account", account, "error", err)
 		return ""
@@ -426,10 +426,10 @@ func discoverTenantID(account string) string {
 	req.Header.Set("x-ms-version", "2020-08-04")
 	resp, err := defaultHTTPClient().Do(req)
 	if err != nil {
-		slog.Debug("tenant discovery: HEAD failed", "account", account, "error", err)
+		slog.Debug("tenant discovery: GET failed", "account", account, "error", err)
 		return ""
 	}
-	resp.Body.Close()
+	_ = resp.Body.Close()
 
 	// WWW-Authenticate: Bearer authorization_uri=https://login.microsoftonline.com/<tenant-id>/oauth2/authorize ...
 	auth := resp.Header.Get("Www-Authenticate")
@@ -467,7 +467,8 @@ func defaultHTTPClient() *http.Client {
 // PreAuthenticate eagerly authenticates to the given storage accounts
 // sequentially. This ensures any interactive login popups happen one at a
 // time before parallel workers start. It also pre-warms the blob client
-// and UDK caches so that no credential acquisition happens during copy.
+// and UDC (User Delegation Credential) caches so that no credential
+// acquisition happens during copy.
 func PreAuthenticate(ctx context.Context, accounts ...string) error {
 	for _, account := range accounts {
 		// Trigger tenant discovery + credential acquisition.
@@ -475,11 +476,11 @@ func PreAuthenticate(ctx context.Context, accounts ...string) error {
 		if err != nil {
 			return fmt.Errorf("pre-authenticate %s: %w", account, err)
 		}
-		// Pre-warm the UDK cache so SAS generation doesn't trigger
+		// Pre-warm the UDC cache so SAS generation doesn't trigger
 		// a second credential acquisition later.
 		_, _, _, _, err = getUDC(ctx, account)
 		if err != nil {
-			slog.Debug("pre-authenticate: UDK warm-up failed (non-fatal)", "account", account, "error", err)
+			slog.Debug("pre-authenticate: UDC warm-up failed (non-fatal)", "account", account, "error", err)
 		}
 	}
 	return nil
@@ -493,8 +494,8 @@ func PreAuthenticate(ctx context.Context, accounts ...string) error {
 //
 // Only one browser popup is opened per tenant; concurrent callers wait for
 // the first to complete.
-func getCredentialForAccount(account string) (azcore.TokenCredential, error) {
-	tid := accountTenantID(account)
+func getCredentialForAccount(ctx context.Context, account string) (azcore.TokenCredential, error) {
+	tid := accountTenantID(ctx, account)
 	if tid == "" {
 		return getDefaultCredential()
 	}
@@ -524,7 +525,7 @@ func getCredentialForAccount(account string) (azcore.TokenCredential, error) {
 	})
 	if err == nil {
 		// Test if CLI credential actually works for this tenant.
-		_, tokenErr := cliCred.GetToken(context.Background(), policy.TokenRequestOptions{
+		_, tokenErr := cliCred.GetToken(ctx, policy.TokenRequestOptions{
 			Scopes: []string{"https://storage.azure.com/.default"},
 		})
 		if tokenErr == nil {
@@ -550,7 +551,7 @@ func getCredentialForAccount(account string) (azcore.TokenCredential, error) {
 	// before any parallel goroutines need the credential. EnableCAE ensures
 	// the cached token includes the CP1 claims that the SDK pipeline will
 	// request later, preventing a second browser popup.
-	_, err = browserCred.GetToken(context.Background(), policy.TokenRequestOptions{
+	_, err = browserCred.GetToken(ctx, policy.TokenRequestOptions{
 		Scopes:    []string{"https://storage.azure.com/.default"},
 		EnableCAE: true,
 	})
@@ -566,9 +567,11 @@ func getCredentialForAccount(account string) (azcore.TokenCredential, error) {
 // The credential is thread-safe and handles token refresh internally.
 func getDefaultCredential() (*azidentity.DefaultAzureCredential, error) {
 	cachedDefaultCredOnce.Do(func() {
-		cachedDefaultCred, cachedDefaultCredErr = azidentity.NewDefaultAzureCredential(&azidentity.DefaultAzureCredentialOptions{
-			AdditionallyAllowedTenants: []string{"*"},
-		})
+		opts := &azidentity.DefaultAzureCredentialOptions{}
+		if strings.EqualFold(os.Getenv("BBB_AZURE_ALLOW_ANY_TENANT"), "true") {
+			opts.AdditionallyAllowedTenants = []string{"*"}
+		}
+		cachedDefaultCred, cachedDefaultCredErr = azidentity.NewDefaultAzureCredential(opts)
 		if cachedDefaultCredErr == nil && slog.Default().Enabled(context.Background(), slog.LevelDebug) {
 			tok, tokErr := cachedDefaultCred.GetToken(context.Background(), policy.TokenRequestOptions{Scopes: []string{"https://storage.azure.com/.default"}})
 			if tokErr == nil {
@@ -611,7 +614,7 @@ func getAzBlobClient(ctx context.Context, account string) (*azblob.Client, error
 			return nil, err
 		}
 	} else {
-		cred, credErr := getCredentialForAccount(account)
+		cred, credErr := getCredentialForAccount(ctx, account)
 		if credErr != nil {
 			return nil, credErr
 		}
@@ -1249,7 +1252,7 @@ func getUDC(ctx context.Context, account string) (*service.UserDelegationCredent
 // refreshUDC performs the actual UDC refresh (network call). Called at most
 // once per account at a time, guarded by udcInflight.
 func refreshUDC(ctx context.Context, account string) (*service.UserDelegationCredential, *service.Client, time.Time, time.Time, error) {
-	cred, err := getCredentialForAccount(account)
+	cred, err := getCredentialForAccount(ctx, account)
 	if err != nil {
 		return nil, nil, time.Time{}, time.Time{}, fmt.Errorf("credential for %s: %w", account, err)
 	}

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -568,6 +568,9 @@ func getCredentialForAccount(ctx context.Context, account string) (azcore.TokenC
 func getDefaultCredential() (*azidentity.DefaultAzureCredential, error) {
 	cachedDefaultCredOnce.Do(func() {
 		opts := &azidentity.DefaultAzureCredentialOptions{}
+		// BBB_AZURE_ALLOW_ANY_TENANT=true permits the default credential to
+		// acquire tokens for any tenant. Without this, cross-tenant requests
+		// may fail. This is opt-in to limit the trust boundary by default.
 		if strings.EqualFold(os.Getenv("BBB_AZURE_ALLOW_ANY_TENANT"), "true") {
 			opts.AdditionallyAllowedTenants = []string{"*"}
 		}

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"io"
+	"net/http"
 	"os"
 	"strings"
 	"testing"
@@ -727,5 +728,146 @@ func TestNameRewriteNestedPrefix(t *testing.T) {
 	got := strings.TrimPrefix(blobName, rootPrefix)
 	if got != "c/d.txt" {
 		t.Fatalf("expected 'c/d.txt', got %q", got)
+	}
+}
+
+// --- Tenant discovery / challenge parsing tests ---
+
+func TestParseTenantFromChallengeValid(t *testing.T) {
+	header := `Bearer authorization_uri="https://login.microsoftonline.com/72f988bf-86f1-41af-91ab-2d7cd011db47/oauth2/authorize" resource_id="https://storage.azure.com"`
+	tid := parseTenantFromChallenge(header)
+	if tid != "72f988bf-86f1-41af-91ab-2d7cd011db47" {
+		t.Fatalf("expected tenant ID '72f988bf-86f1-41af-91ab-2d7cd011db47', got %q", tid)
+	}
+}
+
+func TestParseTenantFromChallengeNoQuotes(t *testing.T) {
+	header := `Bearer authorization_uri=https://login.microsoftonline.com/abcdef01-2345-6789-abcd-ef0123456789/oauth2/authorize`
+	tid := parseTenantFromChallenge(header)
+	if tid != "abcdef01-2345-6789-abcd-ef0123456789" {
+		t.Fatalf("expected tenant ID 'abcdef01-2345-6789-abcd-ef0123456789', got %q", tid)
+	}
+}
+
+func TestParseTenantFromChallengeEmpty(t *testing.T) {
+	if tid := parseTenantFromChallenge(""); tid != "" {
+		t.Fatalf("expected empty tenant ID, got %q", tid)
+	}
+}
+
+func TestParseTenantFromChallengeNoMatch(t *testing.T) {
+	if tid := parseTenantFromChallenge("Bearer realm=example.com"); tid != "" {
+		t.Fatalf("expected empty tenant ID, got %q", tid)
+	}
+}
+
+func TestParseTenantFromChallengeMalformedUUID(t *testing.T) {
+	// 35 chars instead of 36 — should not match.
+	header := `Bearer authorization_uri="https://login.microsoftonline.com/short-uuid/oauth2/authorize"`
+	if tid := parseTenantFromChallenge(header); tid != "" {
+		t.Fatalf("expected empty tenant ID for short UUID, got %q", tid)
+	}
+}
+
+func TestAccountTenantIDEnvUpperCase(t *testing.T) {
+	t.Setenv("BBB_AZ_TENANT_MYACCOUNT", "env-tenant-upper")
+	tid := accountTenantID(context.Background(), "myaccount")
+	if tid != "env-tenant-upper" {
+		t.Fatalf("expected 'env-tenant-upper', got %q", tid)
+	}
+}
+
+func TestAccountTenantIDEnvExactCase(t *testing.T) {
+	t.Setenv("BBB_AZ_TENANT_myMixed", "env-tenant-exact")
+	tid := accountTenantID(context.Background(), "myMixed")
+	if tid != "env-tenant-exact" {
+		t.Fatalf("expected 'env-tenant-exact', got %q", tid)
+	}
+}
+
+func TestAccountTenantIDEnvUpperPrecedence(t *testing.T) {
+	t.Setenv("BBB_AZ_TENANT_MYACCT", "upper-wins")
+	t.Setenv("BBB_AZ_TENANT_myacct", "exact-loses")
+	tid := accountTenantID(context.Background(), "myacct")
+	if tid != "upper-wins" {
+		t.Fatalf("expected upper-case env to take precedence, got %q", tid)
+	}
+}
+
+func TestAccountTenantIDFallsBackToDiscovery(t *testing.T) {
+	// Pre-populate the tenant cache to avoid real HTTP calls.
+	tenantCache.Store("cachedacct", "cached-tenant-id")
+	defer tenantCache.Delete("cachedacct")
+	tid := accountTenantID(context.Background(), "cachedacct")
+	if tid != "cached-tenant-id" {
+		t.Fatalf("expected 'cached-tenant-id', got %q", tid)
+	}
+}
+
+func TestDiscoverTenantIDUsesCache(t *testing.T) {
+	tenantCache.Store("testacct", "from-cache")
+	defer tenantCache.Delete("testacct")
+	tid := discoverTenantID(context.Background(), "testacct")
+	if tid != "from-cache" {
+		t.Fatalf("expected 'from-cache', got %q", tid)
+	}
+}
+
+// roundTripFunc implements http.RoundTripper for test stubbing.
+type roundTripFunc func(*http.Request) (*http.Response, error)
+
+func (f roundTripFunc) RoundTrip(req *http.Request) (*http.Response, error) {
+	return f(req)
+}
+
+func TestDiscoverTenantIDFromHTTP(t *testing.T) {
+	// Replace the default HTTP client with a stubbed transport.
+	origClient := defaultHTTPClientVal
+	defaultHTTPClientOnce.Do(func() {}) // ensure Once is done
+	defaultHTTPClientVal = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: 401,
+				Header: http.Header{
+					"Www-Authenticate": []string{
+						`Bearer authorization_uri="https://login.microsoftonline.com/aabbccdd-1122-3344-5566-778899001122/oauth2/authorize"`,
+					},
+				},
+				Body: io.NopCloser(strings.NewReader("")),
+			}, nil
+		}),
+	}
+	defer func() { defaultHTTPClientVal = origClient }()
+
+	// Clear any cached value for this account.
+	tenantCache.Delete("stubacct")
+	defer tenantCache.Delete("stubacct")
+
+	tid := discoverTenantID(context.Background(), "stubacct")
+	if tid != "aabbccdd-1122-3344-5566-778899001122" {
+		t.Fatalf("expected discovered tenant 'aabbccdd-1122-3344-5566-778899001122', got %q", tid)
+	}
+
+	// Verify it was cached.
+	cached, ok := tenantCache.Load("stubacct")
+	if !ok || cached.(string) != "aabbccdd-1122-3344-5566-778899001122" {
+		t.Fatal("expected tenant ID to be cached after discovery")
+	}
+}
+
+func TestDiscoverTenantIDHTTPError(t *testing.T) {
+	origClient := defaultHTTPClientVal
+	defaultHTTPClientOnce.Do(func() {})
+	defaultHTTPClientVal = &http.Client{
+		Transport: roundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, errors.New("network error")
+		}),
+	}
+	defer func() { defaultHTTPClientVal = origClient }()
+
+	tenantCache.Delete("erroracct")
+	tid := discoverTenantID(context.Background(), "erroracct")
+	if tid != "" {
+		t.Fatalf("expected empty tenant ID on HTTP error, got %q", tid)
 	}
 }

--- a/internal/bbbfs/az.go
+++ b/internal/bbbfs/az.go
@@ -32,7 +32,7 @@ func (azFS) Write(ctx context.Context, path string, r io.Reader) error {
 	if err != nil {
 		return err
 	}
-	return azblob.UploadStream(ctx, ap, r)
+	return azblob.UploadStream(ctx, ap, r, UploadConcurrency(ctx))
 }
 
 func (azFS) List(ctx context.Context, path string) ([]Entry, error) {
@@ -279,6 +279,32 @@ func AzAccountContainer(p string) (account, container string, err error) {
 		return "", "", err
 	}
 	return ap.Account, ap.Container, nil
+}
+
+// PreAuthenticateAz eagerly authenticates to the storage accounts referenced
+// by the given az:// paths. Call this before spawning parallel workers so
+// that any interactive login popups happen sequentially.
+func PreAuthenticateAz(ctx context.Context, paths ...string) error {
+	seen := make(map[string]struct{})
+	var accounts []string
+	for _, p := range paths {
+		if !IsAz(p) {
+			continue
+		}
+		ap, err := azblob.Parse(p)
+		if err != nil {
+			continue
+		}
+		if _, ok := seen[ap.Account]; ok {
+			continue
+		}
+		seen[ap.Account] = struct{}{}
+		accounts = append(accounts, ap.Account)
+	}
+	if len(accounts) == 0 {
+		return nil
+	}
+	return azblob.PreAuthenticate(ctx, accounts...)
 }
 
 // ListRecursiveWithSize lists all entries recursively with their sizes.

--- a/internal/bbbfs/ops.go
+++ b/internal/bbbfs/ops.go
@@ -32,6 +32,22 @@ func ScanConcurrency(ctx context.Context) int {
 	return 1
 }
 
+type uploadConcurrencyKey struct{}
+
+// WithUploadConcurrency returns a context that carries the upload
+// concurrency hint for streaming uploads.
+func WithUploadConcurrency(ctx context.Context, n int) context.Context {
+	return context.WithValue(ctx, uploadConcurrencyKey{}, n)
+}
+
+// UploadConcurrency returns the upload concurrency stored in ctx, or 1 if unset.
+func UploadConcurrency(ctx context.Context) int {
+	if v, ok := ctx.Value(uploadConcurrencyKey{}).(int); ok && v > 0 {
+		return v
+	}
+	return 1
+}
+
 // IsAz returns true if the path targets an Azure Blob Storage backend.
 func IsAz(path string) bool {
 	return azProvider.Match(path)

--- a/main.go
+++ b/main.go
@@ -790,6 +790,18 @@ func cmdCP(ctx context.Context, c *cli.Command) error {
 // their inputs to []taskPair and call this function, ensuring a single code
 // path for state tracking, progress bars, and concurrency control.
 func runCPTasks(ctx context.Context, tasks []taskPair, overwrite, quiet bool, concurrency, retryCount int, stateFile string) error {
+	// Pre-authenticate all Azure accounts before spawning parallel workers.
+	// This ensures interactive login popups happen sequentially, one per tenant.
+	{
+		var paths []string
+		for _, t := range tasks {
+			paths = append(paths, t.src, t.dst)
+		}
+		if err := bbbfs.PreAuthenticateAz(ctx, paths...); err != nil {
+			return err
+		}
+	}
+
 	state, taskCheckpoints, err := loadTaskState(stateFile)
 	if err != nil {
 		return err
@@ -1191,7 +1203,67 @@ func cmdCPPaths(ctx context.Context, overwrite, quiet bool, concurrency, retryCo
 				if copyBar != nil {
 					copyBar.Finish()
 				}
-				return 0, err
+				// Server-side copy failed — fall back to client-side streaming.
+				// This handles cross-tenant copies where the destination cannot
+				// pull from the source even with a SAS URL.
+				slog.Info("server-side copy failed, falling back to client-side streaming",
+					"src", op.src, "dst", op.dst, "error", err)
+
+				// Re-create progress bar for client-side streaming.
+				if showCopyBar {
+					copyBar = newStreamingProgressBar(path.Base(op.src)+" (client)", false, true)
+					if copyBar != nil {
+						copyBar.byteSized = true
+						if size > 0 {
+							copyBar.SetTotal(size)
+						}
+					}
+				}
+
+				reader, readErr := bbbfs.Resolve(op.src).Read(ctx, op.src)
+				if readErr != nil {
+					if copyBar != nil {
+						copyBar.Finish()
+					}
+					return 0, fmt.Errorf("cp: client-side fallback read: %w", readErr)
+				}
+				uploadCtx := bbbfs.WithUploadConcurrency(ctx, blockConcurrency)
+				var streamCopied atomic.Int64
+				writeErr := withReadCloser(reader, func(r io.Reader) error {
+					pr := io.TeeReader(r, &progressWriter{
+						onWrite: func(n int) {
+							copied := streamCopied.Add(int64(n))
+							if onBytes != nil {
+								for {
+									prev := lastReported.Load()
+									if copied <= prev {
+										break
+									}
+									if lastReported.CompareAndSwap(prev, copied) {
+										onBytes(copied - prev)
+										break
+									}
+								}
+							}
+							if copyBar != nil {
+								atomicMax(&copyBar.bytesDone, copied)
+								atomicMax(&copyBar.done, copied)
+								copyBar.render(copied)
+							}
+						},
+					})
+					return bbbfs.Resolve(op.dst).Write(uploadCtx, op.dst, pr)
+				})
+				if copyBar != nil {
+					copyBar.Finish()
+				}
+				if writeErr != nil {
+					return 0, fmt.Errorf("cp: client-side fallback write: %w", writeErr)
+				}
+				if !quiet {
+					lockedPrintf("Copied %s -> %s (client-side)\n", op.src, op.dst)
+				}
+				return size, nil
 			}
 			if copyBar != nil {
 				copyBar.Finish()
@@ -1441,6 +1513,22 @@ func withReadCloser(reader io.ReadCloser, fn func(io.Reader) error) error {
 	}()
 	return fn(reader)
 }
+
+// progressWriter is an io.Writer that calls onWrite with the number of bytes
+// written on each Write call. Used to attach progress reporting to streaming
+// copies.
+type progressWriter struct {
+	onWrite func(n int)
+}
+
+func (pw *progressWriter) Write(p []byte) (int, error) {
+	n := len(p)
+	if pw.onWrite != nil {
+		pw.onWrite(n)
+	}
+	return n, nil
+}
+
 func cmdEdit(ctx context.Context, c *cli.Command) error {
 	slog.Debug("cmdEdit called", "args", c.Args().Slice())
 	if c.Args().Len() != 1 {

--- a/main.go
+++ b/main.go
@@ -8,6 +8,7 @@ import (
 	"io"
 	"net"
 	"net/http"
+	"net/url"
 	"os"
 	"os/exec"
 	"path"
@@ -1206,8 +1207,19 @@ func cmdCPPaths(ctx context.Context, overwrite, quiet bool, concurrency, retryCo
 				// Server-side copy failed — fall back to client-side streaming.
 				// This handles cross-tenant copies where the destination cannot
 				// pull from the source even with a SAS URL.
+				logSrc, logDst := op.src, op.dst
+				if u, err := url.Parse(logSrc); err == nil && u.RawQuery != "" {
+					u.RawQuery = ""
+					u.Fragment = ""
+					logSrc = u.String()
+				}
+				if u, err := url.Parse(logDst); err == nil && u.RawQuery != "" {
+					u.RawQuery = ""
+					u.Fragment = ""
+					logDst = u.String()
+				}
 				slog.Info("server-side copy failed, falling back to client-side streaming",
-					"src", op.src, "dst", op.dst, "error", err)
+					"src", logSrc, "dst", logDst, "error", err)
 
 				// Re-create progress bar for client-side streaming.
 				if showCopyBar {
@@ -1263,7 +1275,10 @@ func cmdCPPaths(ctx context.Context, overwrite, quiet bool, concurrency, retryCo
 				if !quiet {
 					lockedPrintf("Copied %s -> %s (client-side)\n", op.src, op.dst)
 				}
-				return size, nil
+				if size > 0 {
+					return size, nil
+				}
+				return streamCopied.Load(), nil
 			}
 			if copyBar != nil {
 				copyBar.Finish()


### PR DESCRIPTION
- [x] Fix CI lint error: check `resp.Body.Close()` return value in `discoverTenantID`
- [x] Fix `discoverTenantID`: use `http.NewRequestWithContext`, fix "HEAD failed" → "GET failed" log message
- [x] Thread `ctx` through `getCredentialForAccount` instead of using `context.Background()`
- [x] Gate `AdditionallyAllowedTenants: []string{"*"}` behind `BBB_AZURE_ALLOW_ANY_TENANT` env var
- [x] Fix UDK/UDC terminology in comments (PreAuthenticate)
- [x] Scrub SAS query parameters from log messages in main.go fallback path
- [x] Fix return value in client-side fallback to use actual streamed bytes when size unknown
- [x] Add unit tests for `parseTenantFromChallenge`, `accountTenantID`, and `discoverTenantID`
- [x] Document `BBB_AZURE_ALLOW_ANY_TENANT` security implications