### PR TITLE
Adaptive parallel ranged download to match azcopy throughput

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,8 +58,9 @@ The `DNS lookup` line shows the resolved IP addresses for the storage account, a
 | `DST_BBB_AZBLOB_ACCOUNTKEY` | | Shared key for destination storage accounts only |
 | `BBB_PARALLEL_DOWNLOAD` | `1` (on) | Set to `0`, `false`, `no`, or `off` to disable parallel ranged Azure→local single-file downloads and fall back to a single streaming connection |
 | `BBB_PARALLEL_UPLOAD` | `1` (on) | Set to `0`, `false`, `no`, or `off` to disable parallel ranged local→Azure single-file uploads and fall back to the streaming `UploadStream` path |
-| `BBB_AZBLOB_DOWNLOAD_BLOCK_MIB` | `4` | Chunk size in MiB used by the parallel Azure→local download path |
+| `BBB_AZBLOB_DOWNLOAD_BLOCK_MIB` | `16` | Chunk size in MiB used by the parallel Azure→local download path |
 | `BBB_AZBLOB_UPLOAD_BLOCK_MIB` | `64` | Chunk size in MiB used by the parallel local→Azure upload path (clamped so the total block count stays within Azure's per-blob limit) |
+| `BBB_AZBLOB_DOWNLOAD_CONCURRENCY_MAX` | *(auto)* | Hard upper bound on in-flight download ranges for the adaptive concurrency controller (default cap 512) |
 | `BBB_AZBLOB_UPLOAD_CONCURRENCY_MAX` | *(auto)* | Hard upper bound on in-flight upload blocks for the adaptive concurrency controller (default cap 512) |
 | `BBB_AZBLOB_COPY_CONCURRENCY_MAX` | *(auto)* | Hard upper bound on in-flight blocks for Azure→Azure server-side block copies (default cap 256) |
 

--- a/internal/azblob/adaptive.go
+++ b/internal/azblob/adaptive.go
@@ -225,8 +225,10 @@ func envMaxConcurrency(name string, fallback int) int {
 // (and minimum) capacity so existing tuning is preserved; the controller is
 // only allowed to grow upward. Both the caller value and the env override are
 // clamped to hardCap so neither path can spawn more in-flight work than the
-// documented ceiling (each in-flight slot owns a block-sized buffer, so an
-// unbounded value risks OOM).
+// documented ceiling. The env var is documented as a hard upper bound, so
+// when it is lower than the caller-supplied concurrency it also clamps
+// initial/minC down — otherwise --concurrency 64 with env max 8 would still
+// run 64 in-flight slots.
 func adaptiveBounds(concurrency, hardCap int, envMaxName string) (initial, minC, maxC, step int) {
 	if concurrency < 1 {
 		concurrency = 1
@@ -234,19 +236,30 @@ func adaptiveBounds(concurrency, hardCap int, envMaxName string) (initial, minC,
 	if hardCap > 0 && concurrency > hardCap {
 		concurrency = hardCap
 	}
+	// Resolve the effective ceiling first so we can clamp the caller value
+	// down to it when the env override is more restrictive than --concurrency.
+	envCap := 0
+	if envMaxName != "" {
+		envCap = envMaxConcurrency(envMaxName, 0)
+		if hardCap > 0 && envCap > hardCap {
+			envCap = hardCap
+		}
+		if envCap > 0 && concurrency > envCap {
+			concurrency = envCap
+		}
+	}
 	initial = concurrency
 	minC = concurrency
-	// Default ceiling: 4× initial, clamped to hardCap, with a floor so very
-	// small initial values still have room to grow.
-	maxC = concurrency * 4
-	if maxC < 32 {
-		maxC = 32
-	}
-	if hardCap > 0 && maxC > hardCap {
-		maxC = hardCap
-	}
-	if envMaxName != "" {
-		maxC = envMaxConcurrency(envMaxName, maxC)
+	if envCap > 0 {
+		// Explicit env override defines the ceiling exactly.
+		maxC = envCap
+	} else {
+		// Default ceiling: 4× initial, with a floor so very small initial
+		// values still have room to grow, clamped to hardCap.
+		maxC = concurrency * 4
+		if maxC < 32 {
+			maxC = 32
+		}
 		if hardCap > 0 && maxC > hardCap {
 			maxC = hardCap
 		}

--- a/internal/azblob/adaptive.go
+++ b/internal/azblob/adaptive.go
@@ -223,10 +223,16 @@ func envMaxConcurrency(name string, fallback int) int {
 // adaptiveBounds derives (initial, min, max, step) for the controller from the
 // caller-supplied concurrency. The supplied value is treated as the initial
 // (and minimum) capacity so existing tuning is preserved; the controller is
-// only allowed to grow upward.
+// only allowed to grow upward. Both the caller value and the env override are
+// clamped to hardCap so neither path can spawn more in-flight work than the
+// documented ceiling (each in-flight slot owns a block-sized buffer, so an
+// unbounded value risks OOM).
 func adaptiveBounds(concurrency, hardCap int, envMaxName string) (initial, minC, maxC, step int) {
 	if concurrency < 1 {
 		concurrency = 1
+	}
+	if hardCap > 0 && concurrency > hardCap {
+		concurrency = hardCap
 	}
 	initial = concurrency
 	minC = concurrency
@@ -236,11 +242,14 @@ func adaptiveBounds(concurrency, hardCap int, envMaxName string) (initial, minC,
 	if maxC < 32 {
 		maxC = 32
 	}
-	if maxC > hardCap {
+	if hardCap > 0 && maxC > hardCap {
 		maxC = hardCap
 	}
 	if envMaxName != "" {
 		maxC = envMaxConcurrency(envMaxName, maxC)
+		if hardCap > 0 && maxC > hardCap {
+			maxC = hardCap
+		}
 	}
 	if maxC < minC {
 		maxC = minC

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1214,6 +1214,19 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 	return nil
 }
 
+// downloadCopyBufferSize is the per-range io.CopyBuffer size. The default
+// io.Copy buffer is 32 KiB; with 16 MiB ranges that's 512 read/write syscalls
+// per range and quickly becomes CPU-bound on multi-GiB downloads. 1 MiB keeps
+// the syscall count low without ballooning memory (peak ≈ concurrency × 1 MiB).
+const downloadCopyBufferSize = 1 * 1024 * 1024
+
+var downloadCopyBufPool = sync.Pool{
+	New: func() any {
+		buf := make([]byte, downloadCopyBufferSize)
+		return &buf
+	},
+}
+
 // DownloadFile downloads a blob to a local file using parallel ranged GETs.
 // concurrency is the initial parallelism (and floor); an adaptive controller
 // probes higher concurrency while throughput keeps improving, up to
@@ -1330,7 +1343,9 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 				return
 			}
 			body := resp.NewRetryReader(ctx, nil)
-			n, copyErr := io.Copy(io.NewOffsetWriter(file, offset), body)
+			bufPtr := downloadCopyBufPool.Get().(*[]byte)
+			n, copyErr := io.CopyBuffer(io.NewOffsetWriter(file, offset), body, *bufPtr)
+			downloadCopyBufPool.Put(bufPtr)
 			closeErr := body.Close()
 			if copyErr == nil && n != count {
 				copyErr = fmt.Errorf("short download for range [%d,%d): got %d bytes", offset, offset+count, n)

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1227,6 +1227,28 @@ var downloadCopyBufPool = sync.Pool{
 	},
 }
 
+// monotonicProgress wraps onProgress so it is invoked with strictly
+// increasing cumulative byte counts. DownloadFile fans out concurrent ranged
+// GETs; while the atomic counter is monotonic, two goroutines can race to
+// call onProgress with their captured value out of order. The mutex
+// serializes delivery and drops stale values so callers (and UIs that don't
+// already dedupe) never observe the cumulative total going backwards.
+func monotonicProgress(last *atomic.Int64, onProgress func(int64)) func(int64) {
+	if onProgress == nil {
+		return func(int64) {}
+	}
+	var mu sync.Mutex
+	return func(cur int64) {
+		mu.Lock()
+		defer mu.Unlock()
+		if cur <= last.Load() {
+			return
+		}
+		last.Store(cur)
+		onProgress(cur)
+	}
+}
+
 // DownloadFile downloads a blob to a local file using parallel ranged GETs.
 // concurrency is the initial parallelism (and floor); an adaptive controller
 // probes higher concurrency while throughput keeps improving, up to
@@ -1284,6 +1306,13 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 	}
 	sem := newAdaptiveSem(initial, maxC)
 	var written atomic.Int64
+	// lastReported guards onProgress to deliver monotonically increasing
+	// cumulative byte counts. written.Add returns a monotonic value, but two
+	// goroutines may race to invoke onProgress with their captured value in
+	// any order. monotonicProgress filters out stale callbacks so callers
+	// never see the cumulative total go backwards.
+	var lastReported atomic.Int64
+	emitProgress := monotonicProgress(&lastReported, onProgress)
 	ctrlCtx, ctrlCancel := context.WithCancel(ctx)
 	defer ctrlCancel()
 	done := make(chan struct{})
@@ -1369,9 +1398,7 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 				return
 			}
 			cur := written.Add(n)
-			if onProgress != nil {
-				onProgress(cur)
-			}
+			emitProgress(cur)
 		}(offset, count)
 	}
 
@@ -1381,9 +1408,7 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 	if firstErr != nil {
 		return 0, firstErr
 	}
-	if onProgress != nil {
-		onProgress(size)
-	}
+	emitProgress(size)
 	return size, nil
 }
 

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1030,11 +1030,20 @@ func DownloadStream(ctx context.Context, ap AzurePath) (io.ReadCloser, error) {
 }
 
 // downloadBlockSize is the per-range block size used for parallel downloads.
-// It mirrors azcopy's default chunking so a single blob is fetched over many
-// concurrent ranged GETs rather than one sequential stream.
-const downloadBlockSize = 4 * 1024 * 1024 // 4 MiB
+// 16 MiB amortizes per-request HTTP overhead so we can saturate the link with
+// a modest number of in-flight ranges; benchmarking against azcopy shows the
+// throughput plateaus around this size.
+const downloadBlockSize = 16 * 1024 * 1024 // 16 MiB
 
 const downloadBlockSizeEnv = "BBB_AZBLOB_DOWNLOAD_BLOCK_MIB"
+
+// downloadMaxConcurrencyEnv overrides the upper bound the adaptive
+// concurrency controller may grow the per-download parallelism to.
+const downloadMaxConcurrencyEnv = "BBB_AZBLOB_DOWNLOAD_CONCURRENCY_MAX"
+
+// downloadHardConcurrencyCap caps the download adaptive controller's upper
+// bound regardless of caller input. Same rationale as the upload cap.
+const downloadHardConcurrencyCap = 512
 
 // downloadBlockSizeBytes returns the configured download block size in bytes,
 // honoring BBB_AZBLOB_DOWNLOAD_BLOCK_MIB when set to a positive integer.
@@ -1206,9 +1215,11 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 }
 
 // DownloadFile downloads a blob to a local file using parallel ranged GETs.
-// concurrency controls how many ranges are fetched in parallel (>=1). The
-// optional onProgress callback receives the cumulative number of bytes written.
-// Returns the number of bytes downloaded.
+// concurrency is the initial parallelism (and floor); an adaptive controller
+// probes higher concurrency while throughput keeps improving, up to
+// downloadHardConcurrencyCap (overridable via BBB_AZBLOB_DOWNLOAD_CONCURRENCY_MAX).
+// The optional onProgress callback receives the cumulative number of bytes
+// written. Returns the number of bytes downloaded.
 func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency int, onProgress func(int64)) (int64, error) {
 	if ap.Blob == "" || strings.HasSuffix(ap.Blob, "/") {
 		return 0, errors.New("cannot download directory")
@@ -1217,18 +1228,9 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 	if err != nil {
 		return 0, err
 	}
-	if concurrency < 1 {
-		concurrency = 1
-	}
-	if concurrency > math.MaxUint16 {
-		concurrency = math.MaxUint16
-	}
 	blobClient := client.ServiceClient().NewContainerClient(ap.Container).NewBlockBlobClient(ap.Blob)
-	n, err := blobClient.DownloadFile(ctx, file, &blob.DownloadFileOptions{
-		BlockSize:   downloadBlockSizeBytes(),
-		Concurrency: uint16(concurrency),
-		Progress:    onProgress,
-	})
+
+	props, err := blobClient.GetProperties(ctx, nil)
 	if err != nil {
 		var respErr *azcore.ResponseError
 		if errors.As(err, &respErr) && respErr.ErrorCode == "BlobNotFound" {
@@ -1236,7 +1238,138 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 		}
 		return 0, err
 	}
-	return n, nil
+	if props.ContentLength == nil {
+		return 0, fmt.Errorf("blob %s has no content length", ap.String())
+	}
+	size := *props.ContentLength
+	etag := props.ETag
+
+	if size == 0 {
+		if err := file.Truncate(0); err != nil {
+			return 0, err
+		}
+		if onProgress != nil {
+			onProgress(0)
+		}
+		return 0, nil
+	}
+
+	if stat, err := file.Stat(); err == nil && stat.Size() != size {
+		if err := file.Truncate(size); err != nil {
+			return 0, err
+		}
+	}
+
+	blockSize := downloadBlockSizeBytes()
+	initial, minC, maxC, step := adaptiveBounds(concurrency, downloadHardConcurrencyCap, downloadMaxConcurrencyEnv)
+	// Downloads are typically shorter than uploads (one-way, no commit), so
+	// ramp the adaptive controller faster: bigger step + tighter interval so
+	// concurrency reaches its ceiling within a few seconds rather than after
+	// the transfer has already finished.
+	if step < initial {
+		step = initial
+	}
+	sem := newAdaptiveSem(initial, maxC)
+	var written atomic.Int64
+	ctrlCtx, ctrlCancel := context.WithCancel(ctx)
+	defer ctrlCancel()
+	done := make(chan struct{})
+	go runAdaptiveController(ctrlCtx, sem, &written, adaptiveControllerConfig{
+		Min:        minC,
+		Max:        maxC,
+		Step:       step,
+		Interval:   250 * time.Millisecond,
+		Hysteresis: 0.05,
+		LogTag:     "download",
+	}, done)
+
+	ctx, cancel := context.WithCancel(ctx)
+	defer cancel()
+
+	var wg sync.WaitGroup
+	var errMu sync.Mutex
+	var firstErr error
+
+	for offset := int64(0); offset < size; offset += blockSize {
+		if err := ctx.Err(); err != nil {
+			errMu.Lock()
+			if firstErr == nil {
+				firstErr = err
+			}
+			errMu.Unlock()
+			break
+		}
+		if err := sem.Acquire(ctx); err != nil {
+			errMu.Lock()
+			if firstErr == nil {
+				firstErr = err
+			}
+			errMu.Unlock()
+			break
+		}
+		count := min(blockSize, size-offset)
+		wg.Add(1)
+		go func(offset, count int64) {
+			defer func() {
+				sem.Release()
+				wg.Done()
+			}()
+			resp, err := blobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
+				Range:       blob.HTTPRange{Offset: offset, Count: count},
+				AccessConditions: &blob.AccessConditions{
+					ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: etag},
+				},
+			})
+			if err != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = err
+				}
+				errMu.Unlock()
+				cancel()
+				return
+			}
+			body := resp.NewRetryReader(ctx, nil)
+			n, copyErr := io.Copy(io.NewOffsetWriter(file, offset), body)
+			closeErr := body.Close()
+			if copyErr == nil && n != count {
+				copyErr = fmt.Errorf("short download for range [%d,%d): got %d bytes", offset, offset+count, n)
+			}
+			if copyErr != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = copyErr
+				}
+				errMu.Unlock()
+				cancel()
+				return
+			}
+			if closeErr != nil {
+				errMu.Lock()
+				if firstErr == nil {
+					firstErr = closeErr
+				}
+				errMu.Unlock()
+				cancel()
+				return
+			}
+			cur := written.Add(n)
+			if onProgress != nil {
+				onProgress(cur)
+			}
+		}(offset, count)
+	}
+
+	wg.Wait()
+	close(done)
+
+	if firstErr != nil {
+		return 0, firstErr
+	}
+	if onProgress != nil {
+		onProgress(size)
+	}
+	return size, nil
 }
 
 // Upload writes blob (overwrite)

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1227,6 +1227,35 @@ var downloadCopyBufPool = sync.Pool{
 	},
 }
 
+// copyRangeToOffset streams src into dst at the given offset, accumulating
+// reads into buf before issuing a single pwrite per full buffer. io.CopyBuffer
+// performs one write per read, but HTTP/TLS reads typically return a single
+// TLS record (~16 KiB), which made the old implementation issue one 16 KiB
+// pwrite per chunk — ~656k pwrites per 10 GiB blob vs azcopy's ~15k. Batching
+// up to len(buf) bytes (1 MiB by default) before writing cuts pwrite count
+// ~64× and substantially reduces kernel sys time without changing memory use
+// (each in-flight range already owns one pooled buffer).
+func copyRangeToOffset(dst io.WriterAt, offset int64, src io.Reader, buf []byte) (int64, error) {
+	var total int64
+	for {
+		n, rerr := io.ReadFull(src, buf)
+		if n > 0 {
+			if _, werr := dst.WriteAt(buf[:n], offset+total); werr != nil {
+				return total, werr
+			}
+			total += int64(n)
+		}
+		switch rerr {
+		case nil:
+			continue
+		case io.EOF, io.ErrUnexpectedEOF:
+			return total, nil
+		default:
+			return total, rerr
+		}
+	}
+}
+
 // monotonicProgress wraps onProgress so it is invoked with strictly
 // increasing cumulative byte counts. DownloadFile fans out concurrent ranged
 // GETs; while the atomic counter is monotonic, two goroutines can race to
@@ -1373,7 +1402,7 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 			}
 			body := resp.NewRetryReader(ctx, nil)
 			bufPtr := downloadCopyBufPool.Get().(*[]byte)
-			n, copyErr := io.CopyBuffer(io.NewOffsetWriter(file, offset), body, *bufPtr)
+			n, copyErr := copyRangeToOffset(file, offset, body, *bufPtr)
 			downloadCopyBufPool.Put(bufPtr)
 			closeErr := body.Close()
 			if copyErr == nil && n != count {

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1315,7 +1315,7 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 				wg.Done()
 			}()
 			resp, err := blobClient.DownloadStream(ctx, &blob.DownloadStreamOptions{
-				Range:       blob.HTTPRange{Offset: offset, Count: count},
+				Range: blob.HTTPRange{Offset: offset, Count: count},
 				AccessConditions: &blob.AccessConditions{
 					ModifiedAccessConditions: &blob.ModifiedAccessConditions{IfMatch: etag},
 				},

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1305,16 +1305,25 @@ func TestMonotonicProgressConcurrent(t *testing.T) {
 }
 
 type errReader struct {
-	data []byte
-	n    int
-	err  error
+	data    []byte
+	n       int
+	err     error
+	maxRead int // if >0, cap each Read at this many bytes (simulates TLS records)
 }
 
 func (r *errReader) Read(p []byte) (int, error) {
 	if r.n >= len(r.data) {
 		return 0, r.err
 	}
-	n := copy(p, r.data[r.n:])
+	want := len(p)
+	if r.maxRead > 0 && want > r.maxRead {
+		want = r.maxRead
+	}
+	avail := len(r.data) - r.n
+	if want > avail {
+		want = avail
+	}
+	n := copy(p[:want], r.data[r.n:r.n+want])
 	r.n += n
 	if r.n >= len(r.data) {
 		return n, r.err
@@ -1324,13 +1333,15 @@ func (r *errReader) Read(p []byte) (int, error) {
 
 func TestCopyRangeToOffsetBatchesWrites(t *testing.T) {
 	// Simulate small TLS-record-sized reads: 17 chunks of 16 KiB = ~272 KiB.
+	// maxRead caps each Read at 16 KiB so io.ReadFull must loop to fill the
+	// 1 MiB buffer — exercising the very batching the test asserts about.
 	const chunk = 16 * 1024
 	const chunks = 17
 	src := make([]byte, chunk*chunks)
 	for i := range src {
 		src[i] = byte(i)
 	}
-	r := &errReader{data: src, err: io.EOF}
+	r := &errReader{data: src, err: io.EOF, maxRead: chunk}
 
 	dst := &countingWriterAt{}
 	buf := make([]byte, 1*1024*1024)
@@ -1356,12 +1367,15 @@ func TestCopyRangeToOffsetBatchesWrites(t *testing.T) {
 
 func TestCopyRangeToOffsetMultipleBufferLoads(t *testing.T) {
 	// 2.5x buffer size → should produce 3 writes (full, full, partial).
+	// Cap per-read at 100 B so io.ReadFull is forced to loop within each
+	// buffer fill, ensuring the test exercises real batching behavior
+	// regardless of how the underlying reader chunks its output.
 	buf := make([]byte, 1024)
 	src := make([]byte, 2560)
 	for i := range src {
 		src[i] = byte(i * 31)
 	}
-	r := &errReader{data: src, err: io.EOF}
+	r := &errReader{data: src, err: io.EOF, maxRead: 100}
 	dst := &countingWriterAt{}
 	n, err := copyRangeToOffset(dst, 0, r, buf)
 	if err != nil {
@@ -1400,4 +1414,35 @@ func (w *countingWriterAt) WriteAt(p []byte, off int64) (int, error) {
 	w.calls++
 	w.bytes = append(w.bytes, p...)
 	return len(p), nil
+}
+
+func TestAdaptiveBoundsClampsCallerToHardCap(t *testing.T) {
+	// Caller supplies 1000 but hardCap is 512 — neither initial, min, nor
+	// max should exceed 512.
+	initial, minC, maxC, _ := adaptiveBounds(1000, 512, "")
+	if initial > 512 || minC > 512 || maxC > 512 {
+		t.Fatalf("expected all bounds <= 512, got initial=%d min=%d max=%d", initial, minC, maxC)
+	}
+	if initial != 512 || minC != 512 || maxC != 512 {
+		t.Fatalf("expected all bounds clamped to 512, got initial=%d min=%d max=%d", initial, minC, maxC)
+	}
+}
+
+func TestAdaptiveBoundsClampsEnvOverrideToHardCap(t *testing.T) {
+	t.Setenv("TEST_ADAPTIVE_MAX_ENV", "9999")
+	_, _, maxC, _ := adaptiveBounds(8, 512, "TEST_ADAPTIVE_MAX_ENV")
+	if maxC > 512 {
+		t.Fatalf("expected maxC <= hardCap=512, got %d", maxC)
+	}
+	if maxC != 512 {
+		t.Fatalf("expected maxC clamped to 512, got %d", maxC)
+	}
+}
+
+func TestAdaptiveBoundsEnvOverrideWithinCap(t *testing.T) {
+	t.Setenv("TEST_ADAPTIVE_MAX_ENV", "64")
+	_, _, maxC, _ := adaptiveBounds(8, 512, "TEST_ADAPTIVE_MAX_ENV")
+	if maxC != 64 {
+		t.Fatalf("expected env override to set maxC=64, got %d", maxC)
+	}
 }

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -9,6 +9,8 @@ import (
 	"net/http"
 	"os"
 	"strings"
+	"sync"
+	"sync/atomic"
 	"testing"
 
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
@@ -1211,5 +1213,92 @@ func TestGetCredentialForRoleCachesResult(t *testing.T) {
 	// Both calls should return the same cached instance.
 	if cred1 != cred2 {
 		t.Error("expected cached credential to be reused")
+	}
+}
+
+func TestMonotonicProgressNilCallback(t *testing.T) {
+	var last atomic.Int64
+	emit := monotonicProgress(&last, nil)
+	emit(100)
+	emit(50)
+	if got := last.Load(); got != 0 {
+		t.Fatalf("expected last to remain 0 when onProgress nil, got %d", got)
+	}
+}
+
+func TestMonotonicProgressFiltersStale(t *testing.T) {
+	var last atomic.Int64
+	var calls []int64
+	var mu sync.Mutex
+	emit := monotonicProgress(&last, func(v int64) {
+		mu.Lock()
+		calls = append(calls, v)
+		mu.Unlock()
+	})
+
+	emit(10)
+	emit(5)  // stale: must be dropped
+	emit(10) // duplicate: must be dropped
+	emit(20)
+	emit(15) // stale relative to 20: dropped
+	emit(30)
+
+	mu.Lock()
+	defer mu.Unlock()
+	want := []int64{10, 20, 30}
+	if len(calls) != len(want) {
+		t.Fatalf("expected %v, got %v", want, calls)
+	}
+	for i, v := range want {
+		if calls[i] != v {
+			t.Fatalf("call %d: want %d got %d", i, v, calls[i])
+		}
+	}
+	if got := last.Load(); got != 30 {
+		t.Fatalf("expected last=30, got %d", got)
+	}
+}
+
+func TestMonotonicProgressConcurrent(t *testing.T) {
+	var last atomic.Int64
+	var maxSeen atomic.Int64
+	var ordered atomic.Bool
+	ordered.Store(true)
+
+	emit := monotonicProgress(&last, func(v int64) {
+		for {
+			prev := maxSeen.Load()
+			if v <= prev {
+				ordered.Store(false)
+				return
+			}
+			if maxSeen.CompareAndSwap(prev, v) {
+				return
+			}
+		}
+	})
+
+	const goroutines = 32
+	const perG = 100
+	var wg sync.WaitGroup
+	wg.Add(goroutines)
+	for g := 0; g < goroutines; g++ {
+		go func(base int64) {
+			defer wg.Done()
+			for i := 1; i <= perG; i++ {
+				// each goroutine emits values from disjoint ranges,
+				// mimicking concurrent ranged-GETs producing increasing
+				// cumulative totals out of order.
+				emit(base*int64(perG) + int64(i))
+			}
+		}(int64(g))
+	}
+	wg.Wait()
+
+	if !ordered.Load() {
+		t.Fatal("onProgress observed a non-monotonic cumulative value")
+	}
+	if got := last.Load(); got != goroutines*perG {
+		t.Fatalf("expected high water %d, got %d", goroutines*perG, got)
 	}
 }

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1,6 +1,7 @@
 package azblob
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1301,4 +1302,102 @@ func TestMonotonicProgressConcurrent(t *testing.T) {
 	if got := last.Load(); got != goroutines*perG {
 		t.Fatalf("expected high water %d, got %d", goroutines*perG, got)
 	}
+}
+
+type errReader struct {
+	data []byte
+	n    int
+	err  error
+}
+
+func (r *errReader) Read(p []byte) (int, error) {
+	if r.n >= len(r.data) {
+		return 0, r.err
+	}
+	n := copy(p, r.data[r.n:])
+	r.n += n
+	if r.n >= len(r.data) {
+		return n, r.err
+	}
+	return n, nil
+}
+
+func TestCopyRangeToOffsetBatchesWrites(t *testing.T) {
+	// Simulate small TLS-record-sized reads: 17 chunks of 16 KiB = ~272 KiB.
+	const chunk = 16 * 1024
+	const chunks = 17
+	src := make([]byte, chunk*chunks)
+	for i := range src {
+		src[i] = byte(i)
+	}
+	r := &errReader{data: src, err: io.EOF}
+
+	dst := &countingWriterAt{}
+	buf := make([]byte, 1*1024*1024)
+	n, err := copyRangeToOffset(dst, 100, r, buf)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != int64(len(src)) {
+		t.Fatalf("n=%d want %d", n, len(src))
+	}
+	// 272 KiB fits in one 1 MiB buffer, so we expect exactly ONE WriteAt
+	// instead of 17 (io.CopyBuffer would have produced 17).
+	if dst.calls != 1 {
+		t.Fatalf("expected 1 WriteAt, got %d", dst.calls)
+	}
+	if dst.firstOffset != 100 {
+		t.Fatalf("expected offset 100, got %d", dst.firstOffset)
+	}
+	if !bytes.Equal(dst.bytes, src) {
+		t.Fatalf("written bytes do not match source")
+	}
+}
+
+func TestCopyRangeToOffsetMultipleBufferLoads(t *testing.T) {
+	// 2.5x buffer size → should produce 3 writes (full, full, partial).
+	buf := make([]byte, 1024)
+	src := make([]byte, 2560)
+	for i := range src {
+		src[i] = byte(i * 31)
+	}
+	r := &errReader{data: src, err: io.EOF}
+	dst := &countingWriterAt{}
+	n, err := copyRangeToOffset(dst, 0, r, buf)
+	if err != nil {
+		t.Fatalf("copy: %v", err)
+	}
+	if n != int64(len(src)) {
+		t.Fatalf("n=%d", n)
+	}
+	if dst.calls != 3 {
+		t.Fatalf("expected 3 WriteAt calls, got %d", dst.calls)
+	}
+	if !bytes.Equal(dst.bytes, src) {
+		t.Fatalf("byte mismatch")
+	}
+}
+
+func TestCopyRangeToOffsetPropagatesReadError(t *testing.T) {
+	r := &errReader{data: []byte("hi"), err: errors.New("boom")}
+	dst := &countingWriterAt{}
+	_, err := copyRangeToOffset(dst, 0, r, make([]byte, 4))
+	if err == nil || err.Error() != "boom" {
+		t.Fatalf("expected boom error, got %v", err)
+	}
+}
+
+type countingWriterAt struct {
+	calls       int
+	firstOffset int64
+	bytes       []byte
+}
+
+func (w *countingWriterAt) WriteAt(p []byte, off int64) (int, error) {
+	if w.calls == 0 {
+		w.firstOffset = off
+	}
+	w.calls++
+	w.bytes = append(w.bytes, p...)
+	return len(p), nil
 }

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1446,3 +1446,13 @@ func TestAdaptiveBoundsEnvOverrideWithinCap(t *testing.T) {
 		t.Fatalf("expected env override to set maxC=64, got %d", maxC)
 	}
 }
+
+func TestAdaptiveBoundsEnvOverrideClampsCallerDown(t *testing.T) {
+	// --concurrency 64 with env max 8 must produce a semaphore capped at 8
+	// (env var is documented as a hard upper bound).
+	t.Setenv("TEST_ADAPTIVE_MAX_ENV", "8")
+	initial, minC, maxC, _ := adaptiveBounds(64, 512, "TEST_ADAPTIVE_MAX_ENV")
+	if initial != 8 || minC != 8 || maxC != 8 {
+		t.Fatalf("expected env override to clamp all bounds to 8, got initial=%d min=%d max=%d", initial, minC, maxC)
+	}
+}

--- a/internal/e2e/e2e_test.go
+++ b/internal/e2e/e2e_test.go
@@ -1169,6 +1169,75 @@ func TestBasic(t *testing.T) {
 
 }
 
+func TestMultiRangeDownload(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping e2e tests in short mode")
+	}
+	if !waitForEndpointReady(azuriteHost) {
+		t.Skipf("azurite endpoint %s not reachable", azuriteHost)
+	}
+
+	// Ensure container exists; ignore "already exists" race with TestBasic.
+	_, _ = runBBB("az", "mkcontainer", "az://"+azuriteAccount+"/test")
+
+	// Force tiny block sizes so a modest payload exercises the multi-range
+	// planning + concurrent WriteAt + final progress path in DownloadFile.
+	t.Setenv("BBB_AZBLOB_DOWNLOAD_BLOCK_MIB", "1")
+	t.Setenv("BBB_AZBLOB_UPLOAD_BLOCK_MIB", "1")
+
+	// 5 MiB of pseudo-random data — enough to force 5 download ranges at
+	// 1 MiB each, small enough to keep the test fast.
+	const payloadSize = 5 * 1024 * 1024
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte(i*1315423911 + 7)
+	}
+	wantSum := md5.Sum(payload)
+
+	tmpFile, err := os.CreateTemp("", "bbb-e2e-multirange-")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer func() {
+		if rerr := os.Remove(tmpFile.Name()); rerr != nil {
+			t.Logf("cleanup tmp file: %v", rerr)
+		}
+	}()
+	if _, err := tmpFile.Write(payload); err != nil {
+		t.Fatal(err)
+	}
+	if err := tmpFile.Close(); err != nil {
+		t.Fatal(err)
+	}
+
+	remote := "az://" + azuriteAccount + "/test/multirange.bin"
+	if _, err := runBBB("cp", "-f", tmpFile.Name(), remote); err != nil {
+		t.Fatalf("upload failed: %v", err)
+	}
+
+	downloadPath := tmpFile.Name() + ".downloaded"
+	defer func() {
+		if rerr := os.Remove(downloadPath); rerr != nil {
+			t.Logf("cleanup download file: %v", rerr)
+		}
+	}()
+	if _, err := runBBB("cp", "-f", remote, downloadPath); err != nil {
+		t.Fatalf("download failed: %v", err)
+	}
+
+	got, err := os.ReadFile(downloadPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(got) != payloadSize {
+		t.Fatalf("expected %d bytes, got %d", payloadSize, len(got))
+	}
+	gotSum := md5.Sum(got)
+	if gotSum != wantSum {
+		t.Fatalf("md5 mismatch: want %x got %x", wantSum, gotSum)
+	}
+}
+
 func TestHuggingFaceDownload(t *testing.T) {
 	if testing.Short() {
 		t.Skip("skipping e2e tests in short mode")


### PR DESCRIPTION
Follow-up to #87. PR #87 brought single-file uploads and server-side copy in line with (or ahead of) azcopy, but the download path still leaned on the Azure SDK's \`blob.DownloadFile\` and was ~3× slower than azcopy on a 10 GiB benchmark.

### Why

The SDK's \`downloadBuffer\`:
- uses a **fixed** \`Concurrency\` (no adaptive scaling like our upload/s2s paths now do),
- serializes per-range progress through a **single global \`progressLock\`**,
- and with the previous 4 MiB chunk default needs a high concurrency that the SDK doesn't scale to without manual tuning.

Result on hpe3 → public Azure storage, 10 GiB single blob:

| Direction | bbb-go before | bbb-py 1.0.0 | azcopy | bbb-go this PR |
|---|---|---|---|---|
| Download | ~36.5 s | ~18.8 s | ~11.4 s | **~13.6 s** |

(3 runs each; \`bbb cp -f https://…/testfile.bin /tmp/dl_bench/testfile.bin\` vs \`azcopy copy …\`.)

### What

Reimplement \`azblob.DownloadFile\` to mirror \`UploadFile\` / \`copyBlobBlocks\`:

- \`GetProperties\` once to learn \`ContentLength\` and \`ETag\`; truncate the destination file to the blob size.
- Plan fixed-size ranges (\`downloadBlockSizeBytes()\`, default raised from 4 MiB → 16 MiB based on a tuning sweep against the same benchmark blob).
- Dispatch ranges through the existing adaptive primitives — \`newAdaptiveSem\` + \`runAdaptiveController\` — with a new \`BBB_AZBLOB_DOWNLOAD_CONCURRENCY_MAX\` env var and a 512 hard cap (matching upload).
- Per-range goroutine issues \`blobClient.DownloadStream\` with an explicit \`Range\` and an \`IfMatch\` ETag guard, then \`io.Copy\`s the retry-reader into an \`io.NewOffsetWriter(file, offset)\`. \`*os.File.WriteAt\` is safe for concurrent independent offsets.
- Errors propagate via the same \`errMu\`/\`firstErr\`+\`cancel\` pattern as the upload loop. Short reads are detected explicitly.
- Use a tighter controller interval (250 ms) and a larger step for downloads so concurrency reaches its ceiling within the first second or two — important because downloads are wall-time-shorter than uploads (no commit-block-list round trip).

### Env / docs

- \`BBB_AZBLOB_DOWNLOAD_BLOCK_MIB\` default: 4 → **16**
- New: \`BBB_AZBLOB_DOWNLOAD_CONCURRENCY_MAX\` (auto, capped at 512)
- README env-vars table updated.

### Validation

- \`go test -race ./internal/azblob ./internal/bbbfs ./ -count=1\` ✅
- \`golangci-lint run ./...\` → 0 issues ✅
- 10 GiB end-to-end benchmark on hpe3 vs azcopy (above).

Closes the gap identified during post-merge benchmarking of #87.