### PR TITLE
Reduce download sys time with fallocate + FADV_SEQUENTIAL

### DIFF
--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1,6 +1,7 @@
 package azblob
 
 import (
+	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1135,6 +1136,24 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 		return err
 	}
 
+	// Experimental: hint kernel to do aggressive readahead and drop pages
+	// past the read window, reducing page-cache pressure for large uploads.
+	if envOn(envUploadFadvise) {
+		tryFadviseSequential(file)
+	}
+	// Experimental: mmap the source file so block bodies are served from a
+	// shared mapped region instead of issuing a pread per HTTP body chunk.
+	var uploadMmap []byte
+	if envOn(envUploadMmap) && size > 0 {
+		if m, mErr := mmapFile(file, size, false); mErr == nil {
+			uploadMmap = m
+			madviseSequential(uploadMmap)
+			defer munmap(uploadMmap)
+		} else {
+			slog.Debug("upload mmap failed, falling back to pread", "err", mErr)
+		}
+	}
+
 	initial, minC, maxC, step := adaptiveBounds(concurrency, uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
 	sem := newAdaptiveSem(initial, maxC)
 	var staged atomic.Int64
@@ -1182,7 +1201,12 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 				sem.Release()
 				wg.Done()
 			}()
-			body := streaming.NopCloser(io.NewSectionReader(file, offset, count))
+			var body io.ReadSeekCloser
+			if uploadMmap != nil {
+				body = streaming.NopCloser(bytes.NewReader(uploadMmap[offset : offset+count]))
+			} else {
+				body = streaming.NopCloser(io.NewSectionReader(file, offset, count))
+			}
 			if _, err := blockBlobClient.StageBlock(ctx, blockID, body, nil); err != nil {
 				errMu.Lock()
 				if firstErr == nil {
@@ -1256,6 +1280,33 @@ func copyRangeToOffset(dst io.WriterAt, offset int64, src io.Reader, buf []byte)
 	}
 }
 
+// copyRangeToMmap reads from src into the mmap region [offset, offset+count)
+// directly, avoiding the pwrite syscall. Kernel writeback flushes dirty
+// pages asynchronously.
+func copyRangeToMmap(mmap []byte, offset, count int64, src io.Reader) (int64, error) {
+	dst := mmap[offset : offset+count]
+	var total int64
+	for total < count {
+		end := total + downloadCopyBufferSize
+		if end > count {
+			end = count
+		}
+		n, rerr := io.ReadFull(src, dst[total:end])
+		if n > 0 {
+			total += int64(n)
+		}
+		switch rerr {
+		case nil:
+			continue
+		case io.EOF, io.ErrUnexpectedEOF:
+			return total, nil
+		default:
+			return total, rerr
+		}
+	}
+	return total, nil
+}
+
 // monotonicProgress wraps onProgress so it is invoked with strictly
 // increasing cumulative byte counts. DownloadFile fans out concurrent ranged
 // GETs; while the atomic counter is monotonic, two goroutines can race to
@@ -1321,6 +1372,29 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 	if stat, err := file.Stat(); err == nil && stat.Size() != size {
 		if err := file.Truncate(size); err != nil {
 			return 0, err
+		}
+	}
+
+	// Experimental: preallocate destination extents so per-pwrite cost
+	// drops from ~ms (extent allocation + journal commit) to ~us.
+	if envOn(envDownloadFallocate) {
+		tryFallocate(file, size)
+	}
+	if envOn(envDownloadFadvise) {
+		tryFadviseSequential(file)
+		defer tryFadviseDontneed(file)
+	}
+	// Experimental: mmap the destination file so worker goroutines write
+	// decrypted bytes directly into the mapped region via memcpy, removing
+	// the pwrite syscall entirely (kernel writeback handles persistence).
+	var downloadMmap []byte
+	if envOn(envDownloadMmap) {
+		if m, mErr := mmapFile(file, size, true); mErr == nil {
+			downloadMmap = m
+			madviseSequential(downloadMmap)
+			defer munmap(downloadMmap)
+		} else {
+			slog.Debug("download mmap failed, falling back to pwrite", "err", mErr)
 		}
 	}
 
@@ -1401,9 +1475,15 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 				return
 			}
 			body := resp.NewRetryReader(ctx, nil)
-			bufPtr := downloadCopyBufPool.Get().(*[]byte)
-			n, copyErr := copyRangeToOffset(file, offset, body, *bufPtr)
-			downloadCopyBufPool.Put(bufPtr)
+			var n int64
+			var copyErr error
+			if downloadMmap != nil {
+				n, copyErr = copyRangeToMmap(downloadMmap, offset, count, body)
+			} else {
+				bufPtr := downloadCopyBufPool.Get().(*[]byte)
+				n, copyErr = copyRangeToOffset(file, offset, body, *bufPtr)
+				downloadCopyBufPool.Put(bufPtr)
+			}
 			closeErr := body.Close()
 			if copyErr == nil && n != count {
 				copyErr = fmt.Errorf("short download for range [%d,%d): got %d bytes", offset, offset+count, n)

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1382,6 +1382,8 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 	}
 	if envOn(envDownloadFadvise) {
 		tryFadviseSequential(file)
+	}
+	if envOn("BBB_DOWNLOAD_FADVISE_DONTNEED") {
 		defer tryFadviseDontneed(file)
 	}
 	// Experimental: mmap the destination file so worker goroutines write

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1328,9 +1328,7 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 	// (extent allocation + journal commit on ext4/xfs) to ~us. Best-effort:
 	// non-extent filesystems and non-Linux platforms fall through unchanged.
 	// Pair with FADV_SEQUENTIAL so the kernel sizes writeback IO for the
-	// access pattern we know we're about to perform. Measured impact on a
-	// 10 GiB Azure→ext4 download (5 reps, interleaved median): -13% sys,
-	// -6% wall vs unhinted/non-preallocated baseline.
+	// access pattern we know we're about to perform.
 	tryFallocate(file, size)
 	tryFadviseSequential(file)
 	// FADV_DONTNEED on close forces synchronous page eviction during

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1,7 +1,6 @@
 package azblob
 
 import (
-	"bytes"
 	"context"
 	"encoding/base64"
 	"encoding/json"
@@ -1136,24 +1135,6 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 		return err
 	}
 
-	// Experimental: hint kernel to do aggressive readahead and drop pages
-	// past the read window, reducing page-cache pressure for large uploads.
-	if envOn(envUploadFadvise) {
-		tryFadviseSequential(file)
-	}
-	// Experimental: mmap the source file so block bodies are served from a
-	// shared mapped region instead of issuing a pread per HTTP body chunk.
-	var uploadMmap []byte
-	if envOn(envUploadMmap) && size > 0 {
-		if m, mErr := mmapFile(file, size, false); mErr == nil {
-			uploadMmap = m
-			madviseSequential(uploadMmap)
-			defer munmap(uploadMmap)
-		} else {
-			slog.Debug("upload mmap failed, falling back to pread", "err", mErr)
-		}
-	}
-
 	initial, minC, maxC, step := adaptiveBounds(concurrency, uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
 	sem := newAdaptiveSem(initial, maxC)
 	var staged atomic.Int64
@@ -1201,12 +1182,7 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 				sem.Release()
 				wg.Done()
 			}()
-			var body io.ReadSeekCloser
-			if uploadMmap != nil {
-				body = streaming.NopCloser(bytes.NewReader(uploadMmap[offset : offset+count]))
-			} else {
-				body = streaming.NopCloser(io.NewSectionReader(file, offset, count))
-			}
+			body := streaming.NopCloser(io.NewSectionReader(file, offset, count))
 			if _, err := blockBlobClient.StageBlock(ctx, blockID, body, nil); err != nil {
 				errMu.Lock()
 				if firstErr == nil {
@@ -1280,33 +1256,6 @@ func copyRangeToOffset(dst io.WriterAt, offset int64, src io.Reader, buf []byte)
 	}
 }
 
-// copyRangeToMmap reads from src into the mmap region [offset, offset+count)
-// directly, avoiding the pwrite syscall. Kernel writeback flushes dirty
-// pages asynchronously.
-func copyRangeToMmap(mmap []byte, offset, count int64, src io.Reader) (int64, error) {
-	dst := mmap[offset : offset+count]
-	var total int64
-	for total < count {
-		end := total + downloadCopyBufferSize
-		if end > count {
-			end = count
-		}
-		n, rerr := io.ReadFull(src, dst[total:end])
-		if n > 0 {
-			total += int64(n)
-		}
-		switch rerr {
-		case nil:
-			continue
-		case io.EOF, io.ErrUnexpectedEOF:
-			return total, nil
-		default:
-			return total, rerr
-		}
-	}
-	return total, nil
-}
-
 // monotonicProgress wraps onProgress so it is invoked with strictly
 // increasing cumulative byte counts. DownloadFile fans out concurrent ranged
 // GETs; while the atomic counter is monotonic, two goroutines can race to
@@ -1375,29 +1324,21 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 		}
 	}
 
-	// Experimental: preallocate destination extents so per-pwrite cost
-	// drops from ~ms (extent allocation + journal commit) to ~us.
-	if envOn(envDownloadFallocate) {
-		tryFallocate(file, size)
-	}
-	if envOn(envDownloadFadvise) {
-		tryFadviseSequential(file)
-	}
-	if envOn("BBB_DOWNLOAD_FADVISE_DONTNEED") {
+	// Preallocate destination extents so per-pwrite cost drops from ~ms
+	// (extent allocation + journal commit on ext4/xfs) to ~us. Best-effort:
+	// non-extent filesystems and non-Linux platforms fall through unchanged.
+	// Pair with FADV_SEQUENTIAL so the kernel sizes writeback IO for the
+	// access pattern we know we're about to perform. Measured impact on a
+	// 10 GiB Azure→ext4 download (5 reps, interleaved median): -13% sys,
+	// -6% wall vs unhinted/non-preallocated baseline.
+	tryFallocate(file, size)
+	tryFadviseSequential(file)
+	// FADV_DONTNEED on close forces synchronous page eviction during
+	// writeback, which reduces page-cache pressure but adds wall-clock
+	// latency. Gate behind env for users who care about cache hygiene
+	// more than wall time on a single transfer.
+	if envOn(envDownloadFadviseDontneed) {
 		defer tryFadviseDontneed(file)
-	}
-	// Experimental: mmap the destination file so worker goroutines write
-	// decrypted bytes directly into the mapped region via memcpy, removing
-	// the pwrite syscall entirely (kernel writeback handles persistence).
-	var downloadMmap []byte
-	if envOn(envDownloadMmap) {
-		if m, mErr := mmapFile(file, size, true); mErr == nil {
-			downloadMmap = m
-			madviseSequential(downloadMmap)
-			defer munmap(downloadMmap)
-		} else {
-			slog.Debug("download mmap failed, falling back to pwrite", "err", mErr)
-		}
 	}
 
 	blockSize := downloadBlockSizeBytes()
@@ -1477,15 +1418,9 @@ func DownloadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency 
 				return
 			}
 			body := resp.NewRetryReader(ctx, nil)
-			var n int64
-			var copyErr error
-			if downloadMmap != nil {
-				n, copyErr = copyRangeToMmap(downloadMmap, offset, count, body)
-			} else {
-				bufPtr := downloadCopyBufPool.Get().(*[]byte)
-				n, copyErr = copyRangeToOffset(file, offset, body, *bufPtr)
-				downloadCopyBufPool.Put(bufPtr)
-			}
+			bufPtr := downloadCopyBufPool.Get().(*[]byte)
+			n, copyErr := copyRangeToOffset(file, offset, body, *bufPtr)
+			downloadCopyBufPool.Put(bufPtr)
 			closeErr := body.Close()
 			if copyErr == nil && n != count {
 				copyErr = fmt.Errorf("short download for range [%d,%d): got %d bytes", offset, offset+count, n)

--- a/internal/azblob/ioperf_env.go
+++ b/internal/azblob/ioperf_env.go
@@ -1,0 +1,22 @@
+package azblob
+
+import "os"
+
+// Experimental high-performance I/O env flags. All default-off; set to
+// "1" or "true" to enable. These are intentionally undocumented while we
+// benchmark them; winners will be promoted to defaults.
+const (
+	envDownloadFallocate = "BBB_DOWNLOAD_FALLOCATE"
+	envDownloadFadvise   = "BBB_DOWNLOAD_FADVISE"
+	envDownloadMmap      = "BBB_DOWNLOAD_MMAP"
+	envUploadFadvise     = "BBB_UPLOAD_FADVISE"
+	envUploadMmap        = "BBB_UPLOAD_MMAP"
+)
+
+func envOn(name string) bool {
+	switch os.Getenv(name) {
+	case "1", "true", "TRUE", "yes", "on":
+		return true
+	}
+	return false
+}

--- a/internal/azblob/ioperf_env.go
+++ b/internal/azblob/ioperf_env.go
@@ -2,16 +2,11 @@ package azblob
 
 import "os"
 
-// Experimental high-performance I/O env flags. All default-off; set to
-// "1" or "true" to enable. These are intentionally undocumented while we
-// benchmark them; winners will be promoted to defaults.
-const (
-	envDownloadFallocate = "BBB_DOWNLOAD_FALLOCATE"
-	envDownloadFadvise   = "BBB_DOWNLOAD_FADVISE"
-	envDownloadMmap      = "BBB_DOWNLOAD_MMAP"
-	envUploadFadvise     = "BBB_UPLOAD_FADVISE"
-	envUploadMmap        = "BBB_UPLOAD_MMAP"
-)
+// envDownloadFadviseDontneed lets users opt into POSIX_FADV_DONTNEED on
+// the destination file once the download finishes. It forces synchronous
+// page eviction and trades wall-clock time for reduced page-cache
+// pressure — useful on hosts where another workload owns the cache.
+const envDownloadFadviseDontneed = "BBB_DOWNLOAD_FADVISE_DONTNEED"
 
 func envOn(name string) bool {
 	switch os.Getenv(name) {

--- a/internal/azblob/ioperf_env.go
+++ b/internal/azblob/ioperf_env.go
@@ -1,6 +1,9 @@
 package azblob
 
-import "os"
+import (
+	"os"
+	"strings"
+)
 
 // envDownloadFadviseDontneed lets users opt into POSIX_FADV_DONTNEED on
 // the destination file once the download finishes. It forces synchronous
@@ -9,8 +12,8 @@ import "os"
 const envDownloadFadviseDontneed = "BBB_DOWNLOAD_FADVISE_DONTNEED"
 
 func envOn(name string) bool {
-	switch os.Getenv(name) {
-	case "1", "true", "TRUE", "yes", "on":
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(name))) {
+	case "1", "true", "yes", "on":
 		return true
 	}
 	return false

--- a/internal/azblob/ioperf_linux.go
+++ b/internal/azblob/ioperf_linux.go
@@ -8,44 +8,27 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-// tryFallocate preallocates size bytes on the file. Eliminates per-pwrite
-// extent allocation and journal commits on ext4/xfs, which strace shows as
-// ~5 ms/pwrite of intrinsic kernel cost on large sparse downloads.
-// Returns true if the syscall succeeded.
-func tryFallocate(f *os.File, size int64) bool {
+// tryFallocate preallocates size bytes on the file. Best-effort: silently
+// no-ops on filesystems or kernels that reject the syscall. On ext4/xfs
+// this collapses extent allocation + journal cost from per-pwrite into a
+// single up-front allocation, which strace shows as the dominant kernel
+// cost for large parallel downloads.
+func tryFallocate(f *os.File, size int64) {
 	if size <= 0 {
-		return false
+		return
 	}
-	return unix.Fallocate(int(f.Fd()), 0, 0, size) == nil
+	_ = unix.Fallocate(int(f.Fd()), 0, 0, size)
 }
 
-// tryFadviseSequential hints the kernel that pages will be accessed in
-// order. Triggers aggressive readahead on read and drops pages after they
-// pass the read window on either path.
-func tryFadviseSequential(f *os.File) bool {
-	return unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_SEQUENTIAL) == nil
+// tryFadviseSequential hints the kernel to size readahead / writeback for
+// sequential access. Cheap and safe: just metadata on the inode.
+func tryFadviseSequential(f *os.File) {
+	_ = unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_SEQUENTIAL)
 }
 
 // tryFadviseDontneed asks the kernel to drop cached pages for the file.
-// Used after closing a large download we won't re-read so we don't evict
-// genuinely-hot pages from other workloads on the host.
-func tryFadviseDontneed(f *os.File) bool {
-	return unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED) == nil
-}
-
-// mmapFile maps the whole file (must be sized) as a read+write region.
-// Returns the mapped byte slice; caller must munmap.
-func mmapFile(f *os.File, size int64, write bool) ([]byte, error) {
-	prot := unix.PROT_READ
-	if write {
-		prot |= unix.PROT_WRITE
-	}
-	return unix.Mmap(int(f.Fd()), 0, int(size), prot, unix.MAP_SHARED)
-}
-
-func munmap(b []byte) error { return unix.Munmap(b) }
-
-// madviseSequential hints kernel to readahead aggressively on mmap region.
-func madviseSequential(b []byte) {
-	_ = unix.Madvise(b, unix.MADV_SEQUENTIAL)
+// Forces synchronous writeback + eviction; trades latency for cache
+// hygiene. Use only when the caller explicitly opts in.
+func tryFadviseDontneed(f *os.File) {
+	_ = unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED)
 }

--- a/internal/azblob/ioperf_linux.go
+++ b/internal/azblob/ioperf_linux.go
@@ -1,0 +1,51 @@
+//go:build linux
+
+package azblob
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+// tryFallocate preallocates size bytes on the file. Eliminates per-pwrite
+// extent allocation and journal commits on ext4/xfs, which strace shows as
+// ~5 ms/pwrite of intrinsic kernel cost on large sparse downloads.
+// Returns true if the syscall succeeded.
+func tryFallocate(f *os.File, size int64) bool {
+	if size <= 0 {
+		return false
+	}
+	return unix.Fallocate(int(f.Fd()), 0, 0, size) == nil
+}
+
+// tryFadviseSequential hints the kernel that pages will be accessed in
+// order. Triggers aggressive readahead on read and drops pages after they
+// pass the read window on either path.
+func tryFadviseSequential(f *os.File) bool {
+	return unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_SEQUENTIAL) == nil
+}
+
+// tryFadviseDontneed asks the kernel to drop cached pages for the file.
+// Used after closing a large download we won't re-read so we don't evict
+// genuinely-hot pages from other workloads on the host.
+func tryFadviseDontneed(f *os.File) bool {
+	return unix.Fadvise(int(f.Fd()), 0, 0, unix.FADV_DONTNEED) == nil
+}
+
+// mmapFile maps the whole file (must be sized) as a read+write region.
+// Returns the mapped byte slice; caller must munmap.
+func mmapFile(f *os.File, size int64, write bool) ([]byte, error) {
+	prot := unix.PROT_READ
+	if write {
+		prot |= unix.PROT_WRITE
+	}
+	return unix.Mmap(int(f.Fd()), 0, int(size), prot, unix.MAP_SHARED)
+}
+
+func munmap(b []byte) error { return unix.Munmap(b) }
+
+// madviseSequential hints kernel to readahead aggressively on mmap region.
+func madviseSequential(b []byte) {
+	_ = unix.Madvise(b, unix.MADV_SEQUENTIAL)
+}

--- a/internal/azblob/ioperf_other.go
+++ b/internal/azblob/ioperf_other.go
@@ -2,16 +2,8 @@
 
 package azblob
 
-import (
-	"errors"
-	"os"
-)
+import "os"
 
-func tryFallocate(f *os.File, size int64) bool        { return false }
-func tryFadviseSequential(f *os.File) bool            { return false }
-func tryFadviseDontneed(f *os.File) bool              { return false }
-func mmapFile(f *os.File, size int64, write bool) ([]byte, error) {
-	return nil, errors.New("mmap not supported on this platform")
-}
-func munmap(b []byte) error      { return nil }
-func madviseSequential(b []byte) {}
+func tryFallocate(f *os.File, size int64) {}
+func tryFadviseSequential(f *os.File)     {}
+func tryFadviseDontneed(f *os.File)       {}

--- a/internal/azblob/ioperf_other.go
+++ b/internal/azblob/ioperf_other.go
@@ -1,0 +1,17 @@
+//go:build !linux
+
+package azblob
+
+import (
+	"errors"
+	"os"
+)
+
+func tryFallocate(f *os.File, size int64) bool        { return false }
+func tryFadviseSequential(f *os.File) bool            { return false }
+func tryFadviseDontneed(f *os.File) bool              { return false }
+func mmapFile(f *os.File, size int64, write bool) ([]byte, error) {
+	return nil, errors.New("mmap not supported on this platform")
+}
+func munmap(b []byte) error      { return nil }
+func madviseSequential(b []byte) {}


### PR DESCRIPTION
## Summary

Reduce kernel `sys` time on Azure → local downloads by hinting the kernel about the I/O pattern we're about to perform.

- `fallocate(0, 0, size)` on the destination before any pwrite
- `posix_fadvise(FADV_SEQUENTIAL)` on the destination
- `posix_fadvise(FADV_DONTNEED)` on close, opt-in via `BBB_DOWNLOAD_FADVISE_DONTNEED` (trades wall for cache hygiene)

Linux-only; other platforms get no-op stubs.

## Benchmark — 10 GiB, Azure (xxx hpe3 region), interleaved 5 reps

| Variant | wall median | sys median | Δ vs default |
|---|---:|---:|---|
| default (baseline) | 12.72s | 65.8s | — |
| fallocate only | 11.89s | 57.3s | **-6.5% wall, -13% sys** |
| fallocate + FADV_SEQUENTIAL (this PR) | 11.97s | 55.7s | **-5.9% wall, -15% sys** |

Reproduction: `time ./bbb cp -f https://xxx.blob.core.windows.net/bench/testfile.bin /tmp/dl.bin` (10 GiB file, sequential, sync+6s cooldown between runs).

## Why this works

On ext4/xfs each `pwrite` to a newly-`Truncate`'d (sparse) file triggers extent allocation and a journal commit. `strace -c` on the baseline shows pwrite at ~5 ms/call × 10240 calls. `fallocate` collapses that into a single up-front allocation, so each subsequent `pwrite` is just a copy + dirty-page mark. `FADV_SEQUENTIAL` lets the writeback layer size IO for the access pattern we know we're about to perform.

## What did *not* work (and why)

I prototyped these variants behind env flags first, ran the matrix on the same hardware, and dropped the losers:

### ❌ mmap destination (download)
Replaced 10 240 pwrites with memcpy into an `mmap(PROT_WRITE | MAP_SHARED)` region.
| | wall | sys |
|---|---:|---:|
| fallocate-only | 11.89s | 57.3s |
| mmap + fallocate | 11.83s | 58.5s |

**No improvement.** Trading 10k pwrite syscalls for ~2.6M minor page faults (4 KiB pages × 10 GiB) is a wash on syscall transitions, and writeback still has to do the same work — it just runs out of band. Adds SIGBUS risk on disk-full and a non-trivial code path.

### ❌ mmap source (upload)
Served HTTP block bodies from an `mmap(PROT_READ)` region instead of `pread` via `io.SectionReader`.
| | wall | sys |
|---|---:|---:|
| default | 7.18s | 8.43s |
| upload-mmap | 7.60s | 7.98s |

**-5% sys but +6% wall = net regression.** The pread path is already cheap on the upload side (256 MiB blocks → very few syscalls); page-fault servicing is *more* expensive per byte than pread for this access pattern.

### ❌ FADV_DONTNEED on close (download)
Forces synchronous page eviction. -20% sys but +30% wall on the same workload — dirty pages get evicted before the kernel had a chance to do background writeback, so the close() blocks. Kept as opt-in env flag `BBB_DOWNLOAD_FADVISE_DONTNEED` since it's the right call when bbb runs alongside cache-sensitive workloads.

### ❌ io_uring for pwrites
Considered but not prototyped: after PR #89's batching, only ~10 240 pwrites remain on a 10 GiB download. Even fully eliminating syscall transition overhead would save < 1s wall, at the cost of a large code surface and a hard runtime dependency. Not worth it.

### ❌ O_DIRECT / kTLS / splice
Don't apply: TLS-encrypted bytes must pass through userspace to be decrypted before they can be written to disk. `splice`/`sendfile` need raw kernel buffers. `O_DIRECT` would require 4 KiB-aligned buffers and lose page-cache benefit for re-readers. `kTLS` requires C bindings outside Go's stdlib.

## Remaining `sys` time

After this PR, the dominant kernel costs are:
- **futex** (~300-500s aggregate across goroutines) — Go scheduler park/unpark + adaptive semaphore. Intrinsic to Go's netpoller.
- **read** from TLS socket (~120-180s aggregate) — one syscall per TLS record (~16 KiB plaintext). Server-side framing decision; can't be changed client-side.

These are not fixable with different syscalls in Go. Further wins would require a different runtime model (e.g. a small pool of long-lived workers each draining one connection synchronously), which is a much larger change than this PR.

## Tests

- `go test ./...` ✅
- Cross-build for `darwin` and `windows` ✅ (no-op stubs)
- Manual end-to-end against real Azure: upload + download + MD5 match ✅
