### PR TITLE
S2S copy: adaptive block size + fixed high concurrency to match azcopy

### DIFF
--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1755,8 +1755,23 @@ func copySourceOAuth(ctx context.Context, src AzurePath) (string, string, error)
 	if err != nil {
 		return "", "", err
 	}
-	srcURL := fmt.Sprintf("%s/%s/%s", getEndpoint(src.Account), src.Container, src.Blob)
+	// TrimRight defends against BBB_AZBLOB_ENDPOINT values that include a
+	// trailing slash (e.g. "https://%s.blob.core.windows.net/"), which would
+	// otherwise produce a double slash. PathEscape handles blob names
+	// containing spaces, '#', '?', etc.
+	endpoint := strings.TrimRight(getEndpoint(src.Account), "/")
+	srcURL := fmt.Sprintf("%s/%s/%s", endpoint, url.PathEscape(src.Container), pathEscapeBlobName(src.Blob))
 	return srcURL, "Bearer " + tok.Token, nil
+}
+
+// pathEscapeBlobName URL-escapes a blob name segment-by-segment, preserving
+// the '/' separators so blob names with slashes remain valid path segments.
+func pathEscapeBlobName(name string) string {
+	parts := strings.Split(name, "/")
+	for i, p := range parts {
+		parts[i] = url.PathEscape(p)
+	}
+	return strings.Join(parts, "/")
 }
 
 // copyHardConcurrencyCap is the absolute upper bound on parallel
@@ -1773,16 +1788,15 @@ const copyMaxConcurrencyEnv = "BBB_AZBLOB_COPY_CONCURRENCY_MAX"
 const copyDefaultConcurrency = 256
 
 // copyConcurrencyCap returns the parallel StageBlockFromURL cap for a single
-// S2S copy. It honors the caller-provided concurrency (falling back to
-// copyDefaultConcurrency when concurrency <= 0), clamps the result to the
-// block count and to copyHardConcurrencyCap, and lets
-// BBB_AZBLOB_COPY_CONCURRENCY_MAX override the caller's request (still
-// subject to copyHardConcurrencyCap) for ad-hoc tuning.
-func copyConcurrencyCap(concurrency, blockCount int) int {
-	cap := concurrency
-	if cap <= 0 {
-		cap = copyDefaultConcurrency
-	}
+// S2S copy. Because StageBlockFromURL does no client-side buffering, the
+// per-blob fan-out is independent of the caller's --concurrency (which
+// governs client I/O for upload/download). We start from
+// copyDefaultConcurrency, allow BBB_AZBLOB_COPY_CONCURRENCY_MAX to override,
+// and clamp the result to the block count and to copyHardConcurrencyCap.
+// The concurrency parameter is accepted for API symmetry and is currently
+// ignored.
+func copyConcurrencyCap(_ /*concurrency*/, blockCount int) int {
+	cap := copyDefaultConcurrency
 	if env := envMaxConcurrency(copyMaxConcurrencyEnv, 0); env > 0 {
 		cap = env
 	}

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -96,7 +96,8 @@ var validBlobSuffixes = []string{
 const (
 	defaultCopySASExpiry     = time.Hour
 	clockSkewTolerance       = 5 * time.Minute   // backdate SAS start to tolerate clock differences
-	copyBlockSize            = 256 * 1024 * 1024 // 256 MiB per block for StageBlockFromURL
+	copyBlockSize            = 8 * 1024 * 1024 // Default 8 MiB per StageBlockFromURL block; matches azcopy's S2S sweet spot. Smaller blocks let Azure's destination pipeline more PBFU operations in parallel per blob, dramatically improving S2S throughput vs the 256 MiB used for client-side uploads.
+	copyBlockSizeEnv         = "BBB_AZBLOB_COPY_BLOCK_MIB"
 	copyPollInitialDelay     = 100 * time.Millisecond
 	copyPollMaxDelay         = 2 * time.Second
 	uploadStreamMiB          = 1 << 20
@@ -1706,12 +1707,35 @@ const copyHardConcurrencyCap = 256
 
 const copyMaxConcurrencyEnv = "BBB_AZBLOB_COPY_CONCURRENCY_MAX"
 
+// copyBlockSizeBytes returns the StageBlockFromURL block size for a given
+// total transfer size. Defaults to 8 MiB (azcopy's S2S sweet spot, ~30×
+// smaller than what client-side uploads use). Smaller blocks let Azure's
+// destination pipeline far more PBFU operations in parallel per blob;
+// measurements on 10 GiB cross-account copies show ~4× throughput vs the
+// previous 256 MiB block size. The size is grown if needed to stay under
+// blockblob.MaxBlocks=50000, and may be overridden via BBB_AZBLOB_COPY_BLOCK_MIB.
+func copyBlockSizeBytes(size int64) int64 {
+	block := int64(copyBlockSize)
+	if v := os.Getenv(copyBlockSizeEnv); v != "" {
+		if mib, err := strconv.ParseInt(v, 10, 64); err == nil && mib > 0 && mib <= math.MaxInt64/(1024*1024) {
+			block = mib * 1024 * 1024
+		}
+	}
+	if size > 0 {
+		minBlock := (size + int64(blockblob.MaxBlocks) - 1) / int64(blockblob.MaxBlocks)
+		if block < minBlock {
+			block = minBlock
+		}
+	}
+	return block
+}
+
 // copyBlobBlocks copies a blob using parallel StageBlockFromURL + CommitBlockList.
 func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, copySource string, totalSize int64, concurrency int, onProgress CopyProgress) error {
 	blockBlobClient := client.ServiceClient().NewContainerClient(dst.Container).NewBlockBlobClient(dst.Blob)
 
 	// Plan blocks and generate IDs.
-	blkSize, blockIDs, err := planBlocks(totalSize, copyBlockSize, blockblob.MaxBlocks)
+	blkSize, blockIDs, err := planBlocks(totalSize, copyBlockSizeBytes(totalSize), blockblob.MaxBlocks)
 	if err != nil {
 		return err
 	}

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1672,22 +1672,38 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	if err != nil {
 		return err
 	}
-	// Try OAuth-authenticated source first: the destination uses our token to
-	// authenticate against the source via the x-ms-copy-source-authorization
-	// header. This unlocks Azure's intra-region fast path for
-	// UploadBlobFromURL / StageBlockFromURL (~8× faster than SAS-in-URL,
-	// which forces the destination to fetch via the public REST endpoint).
-	// azcopy uses the same approach. We fall back to a SAS URL when no
-	// OAuth credential is available (e.g. cross-tenant copies).
-	srcURL, srcAuth, oauthErr := copySourceOAuth(ctx, src)
-	if oauthErr != nil {
-		slog.Debug("s2s: OAuth source auth unavailable, falling back to SAS", "src", src.String(), "err", oauthErr)
+	// Auth strategy for the source:
+	//   1. If a shared key is configured for the source account, skip the
+	//      OAuth path and go straight to SAS — OAuth would trigger
+	//      DefaultAzureCredential probing (and could open an interactive
+	//      browser) in environments that intentionally use shared-key-only.
+	//   2. Otherwise try OAuth: the destination uses our token to
+	//      authenticate against the source via x-ms-copy-source-authorization,
+	//      which unlocks Azure's intra-region fast path for
+	//      UploadBlobFromURL / StageBlockFromURL (~8× faster than SAS-in-URL,
+	//      which forces the destination to fetch via the public REST
+	//      endpoint). azcopy uses the same approach.
+	//   3. Fall back to SAS when no OAuth credential is available (e.g.
+	//      cross-tenant copies).
+	var srcURL, srcAuth string
+	if accountKey(src.Account) != "" {
 		sasURL, sasErr := blobSASURL(ctx, src)
 		if sasErr != nil {
 			return sasErr
 		}
 		srcURL = sasURL
-		srcAuth = ""
+	} else {
+		var oauthErr error
+		srcURL, srcAuth, oauthErr = copySourceOAuth(ctx, src)
+		if oauthErr != nil {
+			slog.Debug("s2s: OAuth source auth unavailable, falling back to SAS", "src", src.String(), "err", oauthErr)
+			sasURL, sasErr := blobSASURL(ctx, src)
+			if sasErr != nil {
+				return sasErr
+			}
+			srcURL = sasURL
+			srcAuth = ""
+		}
 	}
 
 	// Use provided size when available to avoid a HeadBlob round-trip.

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1697,22 +1697,13 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 		}
 	}
 
-	// For blobs at or below the service's single-shot PutBlobFromURL limit
-	// (5000 MiB), try UploadBlobFromURL first: a single atomic server-side
-	// call that's dramatically faster than staging+committing many blocks.
-	// azcopy uses the same heuristic (see ste/sender.go::getNumChunks +
-	// sender-blockBlobFromURL.go). On failure (e.g. Azurite returns 500
-	// because the API isn't implemented — Azure/Azurite#2402), fall back
-	// silently to the canonical block staging path which will report any
-	// real error.
-	if totalSize >= 0 && totalSize <= copyMaxPutBlobSize {
-		if shotErr := copyBlobSingleShot(ctx, client, dst, srcURL, srcAuth, totalSize, onProgress); shotErr == nil {
-			return nil
-		} else {
-			slog.Debug("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String(), "err", shotErr)
-		}
-	}
-
+	// Always use parallel StageBlockFromURL + CommitBlockList. We previously
+	// tried UploadBlobFromURL (single-shot PutBlobFromURL) first for blobs
+	// up to 5 GiB, but measurements on real Azure showed it's much slower
+	// than parallel block staging because it serializes the entire source
+	// fetch into a single HTTP request on the destination service
+	// (~17s for 1 GiB vs ~2s for the parallel path). azcopy uses parallel
+	// block staging even for small blobs for the same reason.
 	err = copyBlobBlocks(ctx, client, dst, srcURL, srcAuth, totalSize, concurrency, onProgress)
 	if err != nil {
 		// StageBlockFromURL (Put Block From URL) returns 501 in emulators
@@ -1726,37 +1717,6 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 			return copyBlobAsync(ctx, client, dst, srcURL, totalSize, onProgress)
 		}
 		return err
-	}
-	return nil
-}
-
-// copyMaxPutBlobSize is the service-side limit for atomic UploadBlobFromURL
-// (a.k.a. PutBlobFromURL): 5000 MiB. Blobs at or below this size can be
-// copied in a single server-side call, avoiding the per-block latency of
-// StageBlockFromURL + CommitBlockList. Matches azcopy's
-// common.MaxPutBlobSize.
-const copyMaxPutBlobSize = int64(5000) * 1024 * 1024
-
-// copyBlobSingleShot performs a server-side copy via a single
-// UploadBlobFromURL call. Used for blobs <= copyMaxPutBlobSize.
-//
-// When sourceAuth is non-empty, it is passed as
-// x-ms-copy-source-authorization (e.g. "Bearer <token>") so the destination
-// uses OAuth to read the source instead of relying on credentials embedded
-// in the URL (SAS). On Azure, OAuth source-auth triggers the intra-region
-// fast path and is ~8× faster than SAS for same-region copies.
-func copyBlobSingleShot(ctx context.Context, client *azblob.Client, dst AzurePath, copySource, sourceAuth string, totalSize int64, onProgress CopyProgress) error {
-	blockBlobClient := client.ServiceClient().NewContainerClient(dst.Container).NewBlockBlobClient(dst.Blob)
-	var opts *blockblob.UploadBlobFromURLOptions
-	if sourceAuth != "" {
-		opts = &blockblob.UploadBlobFromURLOptions{CopySourceAuthorization: &sourceAuth}
-	}
-	_, err := blockBlobClient.UploadBlobFromURL(ctx, copySource, opts)
-	if err != nil {
-		return err
-	}
-	if onProgress != nil && totalSize >= 0 {
-		onProgress(totalSize, totalSize)
 	}
 	return nil
 }

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1707,6 +1707,12 @@ const copyHardConcurrencyCap = 256
 
 const copyMaxConcurrencyEnv = "BBB_AZBLOB_COPY_CONCURRENCY_MAX"
 
+// copyInitialConcurrency is the starting parallelism for S2S transfers.
+// Mirrors azcopy's default (300, capped at our hard cap of 256). S2S has
+// near-zero per-request resource cost on the client so high initial
+// concurrency is free; the adaptive controller can only reduce from here.
+const copyInitialConcurrency = 256
+
 // copyBlockSizeBytes returns the StageBlockFromURL block size for a given
 // total transfer size. Defaults to 8 MiB (azcopy's S2S sweet spot, ~30×
 // smaller than what client-side uploads use). Smaller blocks let Azure's
@@ -1745,7 +1751,23 @@ func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, c
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
+	// S2S StageBlockFromURL operations don't pass bytes through the client
+	// (server-to-server transfer), so concurrency carries near-zero memory
+	// or CPU cost. Start high instead of ramping from a small value —
+	// otherwise the adaptive controller (4→8→16→… every 750ms) spends
+	// half the transfer below saturation. azcopy defaults to 300 concurrent
+	// operations for the same reason. Use the caller's `concurrency` as a
+	// floor but ensure the initial parallelism is meaningful.
 	initial, minC, maxC, step := adaptiveBounds(concurrency, copyHardConcurrencyCap, copyMaxConcurrencyEnv)
+	if initial < copyInitialConcurrency {
+		initial = copyInitialConcurrency
+		if initial > maxC {
+			initial = maxC
+		}
+		if initial > len(blockIDs) {
+			initial = len(blockIDs)
+		}
+	}
 	sem := newAdaptiveSem(initial, maxC)
 	ctrlCtx, ctrlCancel := context.WithCancel(ctx)
 	defer ctrlCancel()

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1663,9 +1663,9 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	if dst.Blob == "" || strings.HasSuffix(dst.Blob, "/") {
 		return errors.New("destination path is directory-like")
 	}
-	if concurrency < 1 {
-		concurrency = 1
-	}
+	// concurrency <= 0 means "use the default" — copyConcurrencyCap maps
+	// that to copyDefaultConcurrency. Don't clamp to 1 here, or the
+	// fallback in copyConcurrencyCap becomes dead code.
 	client, err := getAzBlobClient(ctx, dst.Account)
 	if err != nil {
 		return err
@@ -1752,10 +1752,11 @@ const copyMaxConcurrencyEnv = "BBB_AZBLOB_COPY_CONCURRENCY_MAX"
 const copyDefaultConcurrency = 256
 
 // copyConcurrencyCap returns the parallel StageBlockFromURL cap for a single
-// S2S copy. It honors the caller-supplied concurrency budget (so
-// `--concurrency` and `cpWorkers × innerConcurrency` still apply) but clamps
-// to the block count and to copyHardConcurrencyCap, and lets
-// BBB_AZBLOB_COPY_CONCURRENCY_MAX override the cap entirely for tuning.
+// S2S copy. It honors the caller-provided concurrency (falling back to
+// copyDefaultConcurrency when concurrency <= 0), clamps the result to the
+// block count and to copyHardConcurrencyCap, and lets
+// BBB_AZBLOB_COPY_CONCURRENCY_MAX override the caller's request (still
+// subject to copyHardConcurrencyCap) for ad-hoc tuning.
 func copyConcurrencyCap(concurrency, blockCount int) int {
 	cap := concurrency
 	if cap <= 0 {

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1753,33 +1753,29 @@ func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, c
 
 	// S2S StageBlockFromURL operations don't pass bytes through the client
 	// (server-to-server transfer), so concurrency carries near-zero memory
-	// or CPU cost. Start high instead of ramping from a small value —
-	// otherwise the adaptive controller (4→8→16→… every 750ms) spends
-	// half the transfer below saturation. azcopy defaults to 300 concurrent
-	// operations for the same reason. Use the caller's `concurrency` as a
-	// floor but ensure the initial parallelism is meaningful.
-	initial, minC, maxC, step := adaptiveBounds(concurrency, copyHardConcurrencyCap, copyMaxConcurrencyEnv)
-	if initial < copyInitialConcurrency {
-		initial = copyInitialConcurrency
-		if initial > maxC {
-			initial = maxC
-		}
-		if initial > len(blockIDs) {
-			initial = len(blockIDs)
-		}
+	// or CPU cost. Use a fixed high concurrency instead of the adaptive
+	// ramp — azcopy defaults to 300 concurrent operations for the same
+	// reason. The adaptive controller's stair-stepped throughput sampling
+	// (driven by block-completion bursts) caused it to throttle down even
+	// when more parallelism would help.
+	_, _, _, _ = adaptiveBounds(concurrency, copyHardConcurrencyCap, copyMaxConcurrencyEnv) // honor env validation, ignore derived bounds
+	fixedCap := copyInitialConcurrency
+	if env := envMaxConcurrency(copyMaxConcurrencyEnv, 0); env > 0 {
+		fixedCap = env
 	}
-	sem := newAdaptiveSem(initial, maxC)
-	ctrlCtx, ctrlCancel := context.WithCancel(ctx)
-	defer ctrlCancel()
-	done := make(chan struct{})
-	go runAdaptiveController(ctrlCtx, sem, &copiedBytes, adaptiveControllerConfig{
-		Min:        minC,
-		Max:        maxC,
-		Step:       step,
-		Interval:   750 * time.Millisecond,
-		Hysteresis: 0.05,
-		LogTag:     "s2s-copy",
-	}, done)
+	if fixedCap > copyHardConcurrencyCap {
+		fixedCap = copyHardConcurrencyCap
+	}
+	if fixedCap > len(blockIDs) {
+		fixedCap = len(blockIDs)
+	}
+	if fixedCap < 1 {
+		fixedCap = 1
+	}
+	sem := newAdaptiveSem(fixedCap, fixedCap)
+	done := make(chan struct{}) // retained for symmetry with other paths
+	_ = done
+	slog.Debug("s2s-copy concurrency", "cap", fixedCap, "blocks", len(blockIDs), "block_size", blkSize)
 
 	var wg sync.WaitGroup
 	var errMu sync.Mutex

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1688,22 +1688,15 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	// (5000 MiB), try UploadBlobFromURL first: a single atomic server-side
 	// call that's dramatically faster than staging+committing many blocks.
 	// azcopy uses the same heuristic (see ste/sender.go::getNumChunks +
-	// sender-blockBlobFromURL.go). On failure, fall back to the async
-	// StartCopyFromURL path before resorting to block staging — Azurite
-	// (and some other emulators) return 500 for UploadBlobFromURL because
-	// the API isn't implemented (Azure/Azurite#2402) but happily process
-	// StartCopyFromURL, completing 1 GiB loopback copies in ~0.2s vs
-	// ~17s for hundreds of parallel block-stage requests.
+	// sender-blockBlobFromURL.go). On failure (e.g. Azurite returns 500
+	// because the API isn't implemented — Azure/Azurite#2402), fall back
+	// silently to the canonical block staging path which will report any
+	// real error.
 	if totalSize >= 0 && totalSize <= copyMaxPutBlobSize {
 		if shotErr := copyBlobSingleShot(ctx, client, dst, copySource, totalSize, onProgress); shotErr == nil {
 			return nil
 		} else {
-			slog.Debug("UploadBlobFromURL failed, trying async StartCopyFromURL", "dst", dst.String(), "err", shotErr)
-		}
-		if asyncErr := copyBlobAsync(ctx, client, dst, copySource, totalSize, onProgress); asyncErr == nil {
-			return nil
-		} else {
-			slog.Debug("StartCopyFromURL failed, falling back to block staging", "dst", dst.String(), "err", asyncErr)
+			slog.Debug("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String(), "err", shotErr)
 		}
 	}
 

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1684,6 +1684,21 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 		}
 	}
 
+	// For blobs at or below the service's single-shot PutBlobFromURL limit
+	// (5000 MiB), use UploadBlobFromURL: a single atomic server-side call
+	// that's dramatically faster than staging+committing many blocks,
+	// especially on emulators with single-threaded loopback. azcopy uses
+	// the same heuristic (see ste/sender.go::getNumChunks: only blobs >
+	// putBlobSize get multi-chunked).
+	if totalSize >= 0 && totalSize <= copyMaxPutBlobSize {
+		if err := copyBlobSingleShot(ctx, client, dst, copySource, totalSize, onProgress); err == nil {
+			return nil
+		} else if !shouldFallbackToBlockStaging(err) {
+			return err
+		}
+		slog.Debug("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String())
+	}
+
 	err = copyBlobBlocks(ctx, client, dst, copySource, totalSize, concurrency, onProgress)
 	if err != nil {
 		// StageBlockFromURL (Put Block From URL) returns 501 in emulators
@@ -1697,6 +1712,39 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 			return copyBlobAsync(ctx, client, dst, copySource, totalSize, onProgress)
 		}
 		return err
+	}
+	return nil
+}
+
+// copyMaxPutBlobSize is the service-side limit for atomic UploadBlobFromURL
+// (a.k.a. PutBlobFromURL): 5000 MiB. Blobs at or below this size can be
+// copied in a single server-side call, avoiding the per-block latency of
+// StageBlockFromURL + CommitBlockList. Matches azcopy's
+// common.MaxPutBlobSize.
+const copyMaxPutBlobSize = int64(5000) * 1024 * 1024
+
+// shouldFallbackToBlockStaging reports whether an UploadBlobFromURL error
+// indicates the API is unsupported (e.g. Azurite emulator returns 501) or
+// the source is too large for a single call (413). In those cases the caller
+// should retry via the multi-block StageBlockFromURL + CommitBlockList path.
+func shouldFallbackToBlockStaging(err error) bool {
+	var respErr *azcore.ResponseError
+	if errors.As(err, &respErr) {
+		return respErr.StatusCode == 501 || respErr.StatusCode == 413
+	}
+	return false
+}
+
+// copyBlobSingleShot performs a server-side copy via a single
+// UploadBlobFromURL call. Used for blobs <= copyMaxPutBlobSize.
+func copyBlobSingleShot(ctx context.Context, client *azblob.Client, dst AzurePath, copySource string, totalSize int64, onProgress CopyProgress) error {
+	blockBlobClient := client.ServiceClient().NewContainerClient(dst.Container).NewBlockBlobClient(dst.Blob)
+	_, err := blockBlobClient.UploadBlobFromURL(ctx, copySource, nil)
+	if err != nil {
+		return err
+	}
+	if onProgress != nil && totalSize >= 0 {
+		onProgress(totalSize, totalSize)
 	}
 	return nil
 }

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1663,9 +1663,11 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	if dst.Blob == "" || strings.HasSuffix(dst.Blob, "/") {
 		return errors.New("destination path is directory-like")
 	}
-	// concurrency <= 0 means "use the default" — copyConcurrencyCap maps
-	// that to copyDefaultConcurrency. Don't clamp to 1 here, or the
-	// fallback in copyConcurrencyCap becomes dead code.
+	// copyConcurrencyCap ignores the caller's concurrency entirely (S2S has
+	// no client-side buffering, so per-blob fan-out is independent of the
+	// CLI --concurrency that governs client I/O). It always starts from
+	// copyDefaultConcurrency, optionally overridden by
+	// BBB_AZBLOB_COPY_CONCURRENCY_MAX, and is clamped to copyHardConcurrencyCap.
 	client, err := getAzBlobClient(ctx, dst.Account)
 	if err != nil {
 		return err
@@ -1781,10 +1783,11 @@ const copyHardConcurrencyCap = 256
 
 const copyMaxConcurrencyEnv = "BBB_AZBLOB_COPY_CONCURRENCY_MAX"
 
-// copyDefaultConcurrency is the fallback parallelism when the caller passes
-// concurrency <= 0. Mirrors azcopy's default of ~300 (capped at our hard
-// cap of 256). S2S has near-zero per-request resource cost on the client
-// so high concurrency is effectively free.
+// copyDefaultConcurrency is the parallel StageBlockFromURL fan-out used for
+// every S2S copy (independent of the caller's --concurrency). Mirrors
+// azcopy's default of ~300, capped at our hard cap of 256. S2S has
+// near-zero per-request resource cost on the client so high concurrency is
+// effectively free.
 const copyDefaultConcurrency = 256
 
 // copyConcurrencyCap returns the parallel StageBlockFromURL cap for a single
@@ -1795,7 +1798,7 @@ const copyDefaultConcurrency = 256
 // and clamp the result to the block count and to copyHardConcurrencyCap.
 // The concurrency parameter is accepted for API symmetry and is currently
 // ignored.
-func copyConcurrencyCap(_ /*concurrency*/, blockCount int) int {
+func copyConcurrencyCap(_ int, blockCount int) int {
 	cap := copyDefaultConcurrency
 	if env := envMaxConcurrency(copyMaxConcurrencyEnv, 0); env > 0 {
 		cap = env

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1685,18 +1685,20 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	}
 
 	// For blobs at or below the service's single-shot PutBlobFromURL limit
-	// (5000 MiB), use UploadBlobFromURL: a single atomic server-side call
+	// (5000 MiB), try UploadBlobFromURL: a single atomic server-side call
 	// that's dramatically faster than staging+committing many blocks,
 	// especially on emulators with single-threaded loopback. azcopy uses
 	// the same heuristic (see ste/sender.go::getNumChunks: only blobs >
-	// putBlobSize get multi-chunked).
+	// putBlobSize get multi-chunked). This is opportunistic — any failure
+	// (including emulator quirks like Azurite returning a generic 500 +
+	// empty body for unsupported APIs) silently falls back to the canonical
+	// block staging path, which will report any real error.
 	if totalSize >= 0 && totalSize <= copyMaxPutBlobSize {
-		if err := copyBlobSingleShot(ctx, client, dst, copySource, totalSize, onProgress); err == nil {
+		if shotErr := copyBlobSingleShot(ctx, client, dst, copySource, totalSize, onProgress); shotErr == nil {
 			return nil
-		} else if !shouldFallbackToBlockStaging(err) {
-			return err
+		} else {
+			slog.Debug("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String(), "err", shotErr)
 		}
-		slog.Warn("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String(), "err", err)
 	}
 
 	err = copyBlobBlocks(ctx, client, dst, copySource, totalSize, concurrency, onProgress)
@@ -1722,18 +1724,6 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 // StageBlockFromURL + CommitBlockList. Matches azcopy's
 // common.MaxPutBlobSize.
 const copyMaxPutBlobSize = int64(5000) * 1024 * 1024
-
-// shouldFallbackToBlockStaging reports whether an UploadBlobFromURL error
-// indicates the API is unsupported (e.g. Azurite emulator returns 501) or
-// the source is too large for a single call (413). In those cases the caller
-// should retry via the multi-block StageBlockFromURL + CommitBlockList path.
-func shouldFallbackToBlockStaging(err error) bool {
-	var respErr *azcore.ResponseError
-	if errors.As(err, &respErr) {
-		return respErr.StatusCode == 501 || respErr.StatusCode == 413
-	}
-	return false
-}
 
 // copyBlobSingleShot performs a server-side copy via a single
 // UploadBlobFromURL call. Used for blobs <= copyMaxPutBlobSize.

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1670,9 +1670,22 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	if err != nil {
 		return err
 	}
-	copySource, err := blobSASURL(ctx, src)
-	if err != nil {
-		return err
+	// Try OAuth-authenticated source first: the destination uses our token to
+	// authenticate against the source via the x-ms-copy-source-authorization
+	// header. This unlocks Azure's intra-region fast path for
+	// UploadBlobFromURL / StageBlockFromURL (~8× faster than SAS-in-URL,
+	// which forces the destination to fetch via the public REST endpoint).
+	// azcopy uses the same approach. We fall back to a SAS URL when no
+	// OAuth credential is available (e.g. cross-tenant copies).
+	srcURL, srcAuth, oauthErr := copySourceOAuth(ctx, src)
+	if oauthErr != nil {
+		slog.Debug("s2s: OAuth source auth unavailable, falling back to SAS", "src", src.String(), "err", oauthErr)
+		sasURL, sasErr := blobSASURL(ctx, src)
+		if sasErr != nil {
+			return sasErr
+		}
+		srcURL = sasURL
+		srcAuth = ""
 	}
 
 	// Use provided size when available to avoid a HeadBlob round-trip.
@@ -1693,14 +1706,14 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	// silently to the canonical block staging path which will report any
 	// real error.
 	if totalSize >= 0 && totalSize <= copyMaxPutBlobSize {
-		if shotErr := copyBlobSingleShot(ctx, client, dst, copySource, totalSize, onProgress); shotErr == nil {
+		if shotErr := copyBlobSingleShot(ctx, client, dst, srcURL, srcAuth, totalSize, onProgress); shotErr == nil {
 			return nil
 		} else {
 			slog.Debug("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String(), "err", shotErr)
 		}
 	}
 
-	err = copyBlobBlocks(ctx, client, dst, copySource, totalSize, concurrency, onProgress)
+	err = copyBlobBlocks(ctx, client, dst, srcURL, srcAuth, totalSize, concurrency, onProgress)
 	if err != nil {
 		// StageBlockFromURL (Put Block From URL) returns 501 in emulators
 		// like Azurite. Fall back to the async StartCopyFromURL approach.
@@ -1710,7 +1723,7 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 		var respErr *azcore.ResponseError
 		if errors.As(err, &respErr) && respErr.StatusCode == 501 {
 			slog.Debug("StageBlockFromURL not supported, falling back to StartCopyFromURL", "dst", dst.String())
-			return copyBlobAsync(ctx, client, dst, copySource, totalSize, onProgress)
+			return copyBlobAsync(ctx, client, dst, srcURL, totalSize, onProgress)
 		}
 		return err
 	}
@@ -1726,9 +1739,19 @@ const copyMaxPutBlobSize = int64(5000) * 1024 * 1024
 
 // copyBlobSingleShot performs a server-side copy via a single
 // UploadBlobFromURL call. Used for blobs <= copyMaxPutBlobSize.
-func copyBlobSingleShot(ctx context.Context, client *azblob.Client, dst AzurePath, copySource string, totalSize int64, onProgress CopyProgress) error {
+//
+// When sourceAuth is non-empty, it is passed as
+// x-ms-copy-source-authorization (e.g. "Bearer <token>") so the destination
+// uses OAuth to read the source instead of relying on credentials embedded
+// in the URL (SAS). On Azure, OAuth source-auth triggers the intra-region
+// fast path and is ~8× faster than SAS for same-region copies.
+func copyBlobSingleShot(ctx context.Context, client *azblob.Client, dst AzurePath, copySource, sourceAuth string, totalSize int64, onProgress CopyProgress) error {
 	blockBlobClient := client.ServiceClient().NewContainerClient(dst.Container).NewBlockBlobClient(dst.Blob)
-	_, err := blockBlobClient.UploadBlobFromURL(ctx, copySource, nil)
+	var opts *blockblob.UploadBlobFromURLOptions
+	if sourceAuth != "" {
+		opts = &blockblob.UploadBlobFromURLOptions{CopySourceAuthorization: &sourceAuth}
+	}
+	_, err := blockBlobClient.UploadBlobFromURL(ctx, copySource, opts)
 	if err != nil {
 		return err
 	}
@@ -1736,6 +1759,27 @@ func copyBlobSingleShot(ctx context.Context, client *azblob.Client, dst AzurePat
 		onProgress(totalSize, totalSize)
 	}
 	return nil
+}
+
+// copySourceOAuth resolves a source blob URL and an OAuth bearer header
+// value (suitable for x-ms-copy-source-authorization) for server-side copy.
+// Returns a non-nil error when no token credential is available for the
+// source account (e.g. anonymous public blob, or cross-tenant copy without
+// credentials configured); callers should fall back to a SAS URL in that
+// case.
+func copySourceOAuth(ctx context.Context, src AzurePath) (string, string, error) {
+	cred, err := getCredentialForAccount(ctx, src.Account)
+	if err != nil {
+		return "", "", err
+	}
+	tok, err := cred.GetToken(ctx, policy.TokenRequestOptions{
+		Scopes: []string{"https://storage.azure.com/.default"},
+	})
+	if err != nil {
+		return "", "", err
+	}
+	srcURL := fmt.Sprintf("%s/%s/%s", getEndpoint(src.Account), src.Container, src.Blob)
+	return srcURL, "Bearer " + tok.Token, nil
 }
 
 // copyHardConcurrencyCap is the absolute upper bound on parallel
@@ -1801,7 +1845,12 @@ func copyBlockSizeBytes(size int64) int64 {
 }
 
 // copyBlobBlocks copies a blob using parallel StageBlockFromURL + CommitBlockList.
-func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, copySource string, totalSize int64, concurrency int, onProgress CopyProgress) error {
+//
+// When sourceAuth is non-empty, it is forwarded as
+// x-ms-copy-source-authorization on every StageBlockFromURL request so the
+// destination uses OAuth to read the source instead of relying on
+// SAS-embedded credentials (~8× faster intra-region on real Azure).
+func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, copySource, sourceAuth string, totalSize int64, concurrency int, onProgress CopyProgress) error {
 	blockBlobClient := client.ServiceClient().NewContainerClient(dst.Container).NewBlockBlobClient(dst.Blob)
 
 	// Plan blocks and generate IDs.
@@ -1858,9 +1907,13 @@ func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, c
 				wg.Done()
 			}()
 
-			_, err := blockBlobClient.StageBlockFromURL(ctx, blockID, copySource, &blockblob.StageBlockFromURLOptions{
+			stageOpts := &blockblob.StageBlockFromURLOptions{
 				Range: blob.HTTPRange{Offset: offset, Count: count},
-			})
+			}
+			if sourceAuth != "" {
+				stageOpts.CopySourceAuthorization = &sourceAuth
+			}
+			_, err := blockBlobClient.StageBlockFromURL(ctx, blockID, copySource, stageOpts)
 			if err != nil {
 				errMu.Lock()
 				if firstErr == nil {

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1697,13 +1697,30 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 		}
 	}
 
-	// Always use parallel StageBlockFromURL + CommitBlockList. We previously
-	// tried UploadBlobFromURL (single-shot PutBlobFromURL) first for blobs
-	// up to 5 GiB, but measurements on real Azure showed it's much slower
-	// than parallel block staging because it serializes the entire source
-	// fetch into a single HTTP request on the destination service
-	// (~17s for 1 GiB vs ~2s for the parallel path). azcopy uses parallel
-	// block staging even for small blobs for the same reason.
+	// Same-account copies are metadata operations on Azure: the source and
+	// destination share the same storage stamp, so StartCopyFromURL
+	// completes essentially instantly regardless of blob size (the bytes
+	// don't physically move). This matches what azcopy does and what we
+	// observe empirically: azcopy completes 10 GiB and 100 GiB same-account
+	// S2S copies in ~2 s. For cross-account copies, async would have to
+	// pull the source over the public REST endpoint and could take a long
+	// time, so we keep parallel StageBlockFromURL for that case (where it
+	// also benefits from CopySourceAuthorization OAuth fast path).
+	if strings.EqualFold(src.Account, dst.Account) {
+		if asyncErr := copyBlobAsync(ctx, client, dst, srcURL, totalSize, onProgress); asyncErr == nil {
+			return nil
+		} else {
+			slog.Debug("same-account StartCopyFromURL failed, falling back to block staging", "dst", dst.String(), "err", asyncErr)
+		}
+	}
+
+	// Parallel StageBlockFromURL + CommitBlockList. We previously tried
+	// UploadBlobFromURL (single-shot PutBlobFromURL) first for blobs up to
+	// 5 GiB, but measurements on real Azure showed it's much slower than
+	// parallel block staging because it serializes the entire source fetch
+	// into a single HTTP request on the destination service (~17 s for
+	// 1 GiB vs ~2 s for the parallel path). azcopy uses parallel block
+	// staging for cross-account copies for the same reason.
 	err = copyBlobBlocks(ctx, client, dst, srcURL, srcAuth, totalSize, concurrency, onProgress)
 	if err != nil {
 		// StageBlockFromURL (Put Block From URL) returns 501 in emulators

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1685,19 +1685,25 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	}
 
 	// For blobs at or below the service's single-shot PutBlobFromURL limit
-	// (5000 MiB), try UploadBlobFromURL: a single atomic server-side call
-	// that's dramatically faster than staging+committing many blocks,
-	// especially on emulators with single-threaded loopback. azcopy uses
-	// the same heuristic (see ste/sender.go::getNumChunks: only blobs >
-	// putBlobSize get multi-chunked). This is opportunistic — any failure
-	// (including emulator quirks like Azurite returning a generic 500 +
-	// empty body for unsupported APIs) silently falls back to the canonical
-	// block staging path, which will report any real error.
+	// (5000 MiB), try UploadBlobFromURL first: a single atomic server-side
+	// call that's dramatically faster than staging+committing many blocks.
+	// azcopy uses the same heuristic (see ste/sender.go::getNumChunks +
+	// sender-blockBlobFromURL.go). On failure, fall back to the async
+	// StartCopyFromURL path before resorting to block staging — Azurite
+	// (and some other emulators) return 500 for UploadBlobFromURL because
+	// the API isn't implemented (Azure/Azurite#2402) but happily process
+	// StartCopyFromURL, completing 1 GiB loopback copies in ~0.2s vs
+	// ~17s for hundreds of parallel block-stage requests.
 	if totalSize >= 0 && totalSize <= copyMaxPutBlobSize {
 		if shotErr := copyBlobSingleShot(ctx, client, dst, copySource, totalSize, onProgress); shotErr == nil {
 			return nil
 		} else {
-			slog.Debug("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String(), "err", shotErr)
+			slog.Debug("UploadBlobFromURL failed, trying async StartCopyFromURL", "dst", dst.String(), "err", shotErr)
+		}
+		if asyncErr := copyBlobAsync(ctx, client, dst, copySource, totalSize, onProgress); asyncErr == nil {
+			return nil
+		} else {
+			slog.Debug("StartCopyFromURL failed, falling back to block staging", "dst", dst.String(), "err", asyncErr)
 		}
 	}
 

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -95,7 +95,7 @@ var validBlobSuffixes = []string{
 
 const (
 	defaultCopySASExpiry     = time.Hour
-	clockSkewTolerance       = 5 * time.Minute   // backdate SAS start to tolerate clock differences
+	clockSkewTolerance       = 5 * time.Minute // backdate SAS start to tolerate clock differences
 	copyBlockSize            = 8 * 1024 * 1024 // Default 8 MiB per StageBlockFromURL block; matches azcopy's S2S sweet spot. Smaller blocks let Azure's destination pipeline more PBFU operations in parallel per blob, dramatically improving S2S throughput vs the 256 MiB used for client-side uploads.
 	copyBlockSizeEnv         = "BBB_AZBLOB_COPY_BLOCK_MIB"
 	copyPollInitialDelay     = 100 * time.Millisecond
@@ -1700,18 +1700,43 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 	return nil
 }
 
-// copyHardConcurrencyCap caps the adaptive controller's upper bound for
-// server-side StageBlockFromURL copies. Overridable via
+// copyHardConcurrencyCap is the absolute upper bound on parallel
+// StageBlockFromURL operations for a single S2S copy. Overridable via
 // BBB_AZBLOB_COPY_CONCURRENCY_MAX.
 const copyHardConcurrencyCap = 256
 
 const copyMaxConcurrencyEnv = "BBB_AZBLOB_COPY_CONCURRENCY_MAX"
 
-// copyInitialConcurrency is the starting parallelism for S2S transfers.
-// Mirrors azcopy's default (300, capped at our hard cap of 256). S2S has
-// near-zero per-request resource cost on the client so high initial
-// concurrency is free; the adaptive controller can only reduce from here.
-const copyInitialConcurrency = 256
+// copyDefaultConcurrency is the fallback parallelism when the caller passes
+// concurrency <= 0. Mirrors azcopy's default of ~300 (capped at our hard
+// cap of 256). S2S has near-zero per-request resource cost on the client
+// so high concurrency is effectively free.
+const copyDefaultConcurrency = 256
+
+// copyConcurrencyCap returns the parallel StageBlockFromURL cap for a single
+// S2S copy. It honors the caller-supplied concurrency budget (so
+// `--concurrency` and `cpWorkers × innerConcurrency` still apply) but clamps
+// to the block count and to copyHardConcurrencyCap, and lets
+// BBB_AZBLOB_COPY_CONCURRENCY_MAX override the cap entirely for tuning.
+func copyConcurrencyCap(concurrency, blockCount int) int {
+	cap := concurrency
+	if cap <= 0 {
+		cap = copyDefaultConcurrency
+	}
+	if env := envMaxConcurrency(copyMaxConcurrencyEnv, 0); env > 0 {
+		cap = env
+	}
+	if cap > copyHardConcurrencyCap {
+		cap = copyHardConcurrencyCap
+	}
+	if cap > blockCount && blockCount >= 1 {
+		cap = blockCount
+	}
+	if cap < 1 {
+		cap = 1
+	}
+	return cap
+}
 
 // copyBlockSizeBytes returns the StageBlockFromURL block size for a given
 // total transfer size. Defaults to 8 MiB (azcopy's S2S sweet spot, ~30×
@@ -1753,28 +1778,13 @@ func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, c
 
 	// S2S StageBlockFromURL operations don't pass bytes through the client
 	// (server-to-server transfer), so concurrency carries near-zero memory
-	// or CPU cost. Use a fixed high concurrency instead of the adaptive
-	// ramp — azcopy defaults to 300 concurrent operations for the same
-	// reason. The adaptive controller's stair-stepped throughput sampling
-	// (driven by block-completion bursts) caused it to throttle down even
-	// when more parallelism would help.
-	_, _, _, _ = adaptiveBounds(concurrency, copyHardConcurrencyCap, copyMaxConcurrencyEnv) // honor env validation, ignore derived bounds
-	fixedCap := copyInitialConcurrency
-	if env := envMaxConcurrency(copyMaxConcurrencyEnv, 0); env > 0 {
-		fixedCap = env
-	}
-	if fixedCap > copyHardConcurrencyCap {
-		fixedCap = copyHardConcurrencyCap
-	}
-	if fixedCap > len(blockIDs) {
-		fixedCap = len(blockIDs)
-	}
-	if fixedCap < 1 {
-		fixedCap = 1
-	}
+	// or CPU cost. Use a fixed cap instead of the adaptive ramp — azcopy
+	// defaults to 300 concurrent operations for the same reason. The
+	// adaptive controller's stair-stepped throughput sampling (driven by
+	// block-completion bursts) caused it to throttle down even when more
+	// parallelism would help.
+	fixedCap := copyConcurrencyCap(concurrency, len(blockIDs))
 	sem := newAdaptiveSem(fixedCap, fixedCap)
-	done := make(chan struct{}) // retained for symmetry with other paths
-	_ = done
 	slog.Debug("s2s-copy concurrency", "cap", fixedCap, "blocks", len(blockIDs), "block_size", blkSize)
 
 	var wg sync.WaitGroup
@@ -1830,7 +1840,6 @@ func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, c
 	}
 
 	wg.Wait()
-	close(done)
 
 	if firstErr != nil {
 		return firstErr

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1696,7 +1696,7 @@ func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concu
 		} else if !shouldFallbackToBlockStaging(err) {
 			return err
 		}
-		slog.Debug("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String())
+		slog.Warn("UploadBlobFromURL failed, falling back to block staging", "dst", dst.String(), "err", err)
 	}
 
 	err = copyBlobBlocks(ctx, client, dst, copySource, totalSize, concurrency, onProgress)

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -14,6 +14,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 )
@@ -1559,5 +1560,37 @@ func TestCopyConcurrencyCapMinimumOne(t *testing.T) {
 	t.Setenv(copyMaxConcurrencyEnv, "")
 	if got := copyConcurrencyCap(0, 1); got != 1 {
 		t.Fatalf("expected minimum cap of 1 for single-block transfer, got %d", got)
+	}
+}
+
+func TestShouldFallbackToBlockStaging(t *testing.T) {
+	cases := []struct {
+		name string
+		err  error
+		want bool
+	}{
+		{"501 not implemented (Azurite)", &azcore.ResponseError{StatusCode: 501}, true},
+		{"413 payload too large", &azcore.ResponseError{StatusCode: 413}, true},
+		{"403 forbidden (real auth error)", &azcore.ResponseError{StatusCode: 403}, false},
+		{"500 server error", &azcore.ResponseError{StatusCode: 500}, false},
+		{"non-Azure error", errors.New("network"), false},
+		{"nil", nil, false},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := shouldFallbackToBlockStaging(c.err); got != c.want {
+				t.Fatalf("shouldFallbackToBlockStaging(%v) = %v, want %v", c.err, got, c.want)
+			}
+		})
+	}
+}
+
+func TestCopyMaxPutBlobSizeMatchesAzcopy(t *testing.T) {
+	// azcopy's common.MaxPutBlobSize is 5000 MiB; mirror exactly so the
+	// "small enough for single-shot" heuristic agrees with azcopy and the
+	// Azure REST API's documented limit for PutBlobFromURL.
+	want := int64(5000) * 1024 * 1024
+	if copyMaxPutBlobSize != want {
+		t.Fatalf("copyMaxPutBlobSize = %d, want %d (azcopy parity)", copyMaxPutBlobSize, want)
 	}
 }

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -14,7 +14,6 @@ import (
 	"sync/atomic"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 )
@@ -1560,28 +1559,6 @@ func TestCopyConcurrencyCapMinimumOne(t *testing.T) {
 	t.Setenv(copyMaxConcurrencyEnv, "")
 	if got := copyConcurrencyCap(0, 1); got != 1 {
 		t.Fatalf("expected minimum cap of 1 for single-block transfer, got %d", got)
-	}
-}
-
-func TestShouldFallbackToBlockStaging(t *testing.T) {
-	cases := []struct {
-		name string
-		err  error
-		want bool
-	}{
-		{"501 not implemented (Azurite)", &azcore.ResponseError{StatusCode: 501}, true},
-		{"413 payload too large", &azcore.ResponseError{StatusCode: 413}, true},
-		{"403 forbidden (real auth error)", &azcore.ResponseError{StatusCode: 403}, false},
-		{"500 server error", &azcore.ResponseError{StatusCode: 500}, false},
-		{"non-Azure error", errors.New("network"), false},
-		{"nil", nil, false},
-	}
-	for _, c := range cases {
-		t.Run(c.name, func(t *testing.T) {
-			if got := shouldFallbackToBlockStaging(c.err); got != c.want {
-				t.Fatalf("shouldFallbackToBlockStaging(%v) = %v, want %v", c.err, got, c.want)
-			}
-		})
 	}
 }
 

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1508,8 +1508,9 @@ func TestCopyBlockSizeAutoGrowsAboveMaxBlocks(t *testing.T) {
 // default concurrency=4 and immediately throttled S2S parallelism down to
 // 32, even when 256 concurrent StageBlockFromURL calls would still be cheap
 // (no client-side buffering). The S2S path now uses copyConcurrencyCap
-// directly, which honors the passed-in concurrency without the adaptive
-// controller's stair-stepped throttling.
+// directly, which ignores the caller's concurrency (S2S has no client-side
+// buffering, so per-blob fan-out is decoupled from the CLI --concurrency)
+// and always starts from copyDefaultConcurrency.
 func TestCopyConcurrencyCapBypassesAdaptiveThrottling(t *testing.T) {
 	t.Setenv(copyMaxConcurrencyEnv, "")
 	// Pre-fix behavior: adaptiveBounds(4, 256, env) returned maxC=32, so the
@@ -1526,12 +1527,14 @@ func TestCopyConcurrencyCapBypassesAdaptiveThrottling(t *testing.T) {
 }
 
 func TestCopyConcurrencyCapDefaultsWhenZero(t *testing.T) {
+	// The caller's concurrency is ignored for S2S; the cap always starts
+	// from copyDefaultConcurrency regardless of the value passed in.
 	t.Setenv(copyMaxConcurrencyEnv, "")
 	if got := copyConcurrencyCap(0, 10000); got != copyDefaultConcurrency {
-		t.Fatalf("expected default %d when concurrency=0, got %d", copyDefaultConcurrency, got)
+		t.Fatalf("expected default %d when caller concurrency=0, got %d", copyDefaultConcurrency, got)
 	}
 	if got := copyConcurrencyCap(-1, 10000); got != copyDefaultConcurrency {
-		t.Fatalf("expected default %d when concurrency<0, got %d", copyDefaultConcurrency, got)
+		t.Fatalf("expected default %d when caller concurrency<0, got %d", copyDefaultConcurrency, got)
 	}
 }
 

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1561,13 +1561,3 @@ func TestCopyConcurrencyCapMinimumOne(t *testing.T) {
 		t.Fatalf("expected minimum cap of 1 for single-block transfer, got %d", got)
 	}
 }
-
-func TestCopyMaxPutBlobSizeMatchesAzcopy(t *testing.T) {
-	// azcopy's common.MaxPutBlobSize is 5000 MiB; mirror exactly so the
-	// "small enough for single-shot" heuristic agrees with azcopy and the
-	// Azure REST API's documented limit for PutBlobFromURL.
-	want := int64(5000) * 1024 * 1024
-	if copyMaxPutBlobSize != want {
-		t.Fatalf("copyMaxPutBlobSize = %d, want %d (azcopy parity)", copyMaxPutBlobSize, want)
-	}
-}

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -8,6 +8,7 @@ import (
 	"errors"
 	"io"
 	"net/http"
+	"net/url"
 	"os"
 	"strings"
 	"sync"
@@ -1457,7 +1458,7 @@ func TestAdaptiveBoundsEnvOverrideClampsCallerDown(t *testing.T) {
 	}
 }
 
-// --- S2S copy: block size + concurrency cap (regression tests for PR #93) ---
+// --- S2S copy: block size + concurrency cap regression tests ---
 
 func TestCopyBlockSizeDefault(t *testing.T) {
 	t.Setenv(copyBlockSizeEnv, "")
@@ -1502,23 +1503,23 @@ func TestCopyBlockSizeAutoGrowsAboveMaxBlocks(t *testing.T) {
 	}
 }
 
-// TestCopyConcurrencyCapBypassesAdaptiveThrottling is the regression test for
-// the bug fixed in PR #93: the adaptive controller derived maxC=32 from the
-// caller's default concurrency=4 and immediately throttled S2S parallelism
-// down to 32, even when 256 concurrent StageBlockFromURL calls would still be
-// cheap (no client-side buffering). The S2S path now uses copyConcurrencyCap
+// TestCopyConcurrencyCapBypassesAdaptiveThrottling guards against a
+// regression where the adaptive controller derived maxC=32 from the caller's
+// default concurrency=4 and immediately throttled S2S parallelism down to
+// 32, even when 256 concurrent StageBlockFromURL calls would still be cheap
+// (no client-side buffering). The S2S path now uses copyConcurrencyCap
 // directly, which honors the passed-in concurrency without the adaptive
 // controller's stair-stepped throttling.
 func TestCopyConcurrencyCapBypassesAdaptiveThrottling(t *testing.T) {
 	t.Setenv(copyMaxConcurrencyEnv, "")
 	// Pre-fix behavior: adaptiveBounds(4, 256, env) returned maxC=32, so the
 	// controller would throttle a fresh sem(initial=256, max=32) to 32.
-	// Post-fix: copyConcurrencyCap(4, 1000) honors the caller value of 4.
-	if got := copyConcurrencyCap(4, 1000); got != 4 {
-		t.Fatalf("expected cap to honor caller concurrency=4, got %d", got)
+	// Post-fix: copyConcurrencyCap ignores the caller's concurrency (which
+	// only governs client-side I/O) and uses the S2S default, clamped to
+	// the hard cap. So copyConcurrencyCap(4, 1000) == copyHardConcurrencyCap.
+	if got := copyConcurrencyCap(4, 1000); got != copyHardConcurrencyCap {
+		t.Fatalf("expected cap to ignore caller concurrency and clamp at hard cap %d, got %d", copyHardConcurrencyCap, got)
 	}
-	// And a large caller value rides up to the hard cap, not the
-	// adaptive-derived 32 the old controller would have settled at.
 	if got := copyConcurrencyCap(1024, 5000); got != copyHardConcurrencyCap {
 		t.Fatalf("expected cap to clamp at hard cap %d, got %d", copyHardConcurrencyCap, got)
 	}
@@ -1559,5 +1560,36 @@ func TestCopyConcurrencyCapMinimumOne(t *testing.T) {
 	t.Setenv(copyMaxConcurrencyEnv, "")
 	if got := copyConcurrencyCap(0, 1); got != 1 {
 		t.Fatalf("expected minimum cap of 1 for single-block transfer, got %d", got)
+	}
+}
+
+func TestPathEscapeBlobName(t *testing.T) {
+	cases := map[string]string{
+		"simple.bin":            "simple.bin",
+		"dir/sub/blob.bin":      "dir/sub/blob.bin",
+		"with space.bin":        "with%20space.bin",
+		"weird#name?.bin":       "weird%23name%3F.bin",
+		"a/b c/d#e":             "a/b%20c/d%23e",
+	}
+	for in, want := range cases {
+		if got := pathEscapeBlobName(in); got != want {
+			t.Errorf("pathEscapeBlobName(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+// TestCopySourceOAuthURLNoDoubleSlash verifies that BBB_AZBLOB_ENDPOINT
+// values with a trailing slash (e.g. "https://%s.blob.core.windows.net/")
+// do not produce a malformed "host//container/blob" URL, which previously
+// broke StageBlockFromURL when the benchmark harness configured the
+// endpoint with the trailing slash.
+func TestCopySourceOAuthURLNoDoubleSlash(t *testing.T) {
+	t.Setenv("BBB_AZBLOB_ENDPOINT", "https://%s.blob.core.windows.net/")
+	endpoint := strings.TrimRight(getEndpoint("acct"), "/")
+	src := AzurePath{Account: "acct", Container: "c", Blob: "dir/blob name.bin"}
+	srcURL := endpoint + "/" + url.PathEscape(src.Container) + "/" + pathEscapeBlobName(src.Blob)
+	want := "https://acct.blob.core.windows.net/c/dir/blob%20name.bin"
+	if srcURL != want {
+		t.Fatalf("source URL = %q, want %q", srcURL, want)
 	}
 }

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1456,3 +1456,108 @@ func TestAdaptiveBoundsEnvOverrideClampsCallerDown(t *testing.T) {
 		t.Fatalf("expected env override to clamp all bounds to 8, got initial=%d min=%d max=%d", initial, minC, maxC)
 	}
 }
+
+// --- S2S copy: block size + concurrency cap (regression tests for PR #93) ---
+
+func TestCopyBlockSizeDefault(t *testing.T) {
+	t.Setenv(copyBlockSizeEnv, "")
+	if got := copyBlockSizeBytes(0); got != int64(copyBlockSize) {
+		t.Fatalf("expected default block size %d, got %d", copyBlockSize, got)
+	}
+	if got := copyBlockSizeBytes(1 << 30); got != int64(copyBlockSize) {
+		t.Fatalf("expected default block size %d for 1 GiB transfer, got %d", copyBlockSize, got)
+	}
+}
+
+func TestCopyBlockSizeEnvOverride(t *testing.T) {
+	t.Setenv(copyBlockSizeEnv, "32")
+	if got := copyBlockSizeBytes(1 << 30); got != 32*1024*1024 {
+		t.Fatalf("expected env override to 32 MiB, got %d", got)
+	}
+}
+
+func TestCopyBlockSizeInvalidEnvIgnored(t *testing.T) {
+	for _, v := range []string{"", "0", "-1", "abc"} {
+		t.Run(v, func(t *testing.T) {
+			t.Setenv(copyBlockSizeEnv, v)
+			if got := copyBlockSizeBytes(1 << 20); got != int64(copyBlockSize) {
+				t.Fatalf("expected invalid env %q to fall back to default, got %d", v, got)
+			}
+		})
+	}
+}
+
+func TestCopyBlockSizeAutoGrowsAboveMaxBlocks(t *testing.T) {
+	// A blob far larger than copyBlockSize * MaxBlocks must auto-grow the
+	// block size so the plan fits under blockblob.MaxBlocks=50000.
+	t.Setenv(copyBlockSizeEnv, "")
+	const size = int64(copyBlockSize) * 60000 // 60k * 8 MiB > MaxBlocks
+	got := copyBlockSizeBytes(size)
+	maxBlocks := int64(50000) // blockblob.MaxBlocks
+	if got < int64(copyBlockSize) {
+		t.Fatalf("block size should not shrink, got %d", got)
+	}
+	if (size+got-1)/got > maxBlocks {
+		t.Fatalf("auto-grown block size %d still produces > MaxBlocks blocks for size %d", got, size)
+	}
+}
+
+// TestCopyConcurrencyCapBypassesAdaptiveThrottling is the regression test for
+// the bug fixed in PR #93: the adaptive controller derived maxC=32 from the
+// caller's default concurrency=4 and immediately throttled S2S parallelism
+// down to 32, even when 256 concurrent StageBlockFromURL calls would still be
+// cheap (no client-side buffering). The S2S path now uses copyConcurrencyCap
+// directly, which honors the passed-in concurrency without the adaptive
+// controller's stair-stepped throttling.
+func TestCopyConcurrencyCapBypassesAdaptiveThrottling(t *testing.T) {
+	t.Setenv(copyMaxConcurrencyEnv, "")
+	// Pre-fix behavior: adaptiveBounds(4, 256, env) returned maxC=32, so the
+	// controller would throttle a fresh sem(initial=256, max=32) to 32.
+	// Post-fix: copyConcurrencyCap(4, 1000) honors the caller value of 4.
+	if got := copyConcurrencyCap(4, 1000); got != 4 {
+		t.Fatalf("expected cap to honor caller concurrency=4, got %d", got)
+	}
+	// And a large caller value rides up to the hard cap, not the
+	// adaptive-derived 32 the old controller would have settled at.
+	if got := copyConcurrencyCap(1024, 5000); got != copyHardConcurrencyCap {
+		t.Fatalf("expected cap to clamp at hard cap %d, got %d", copyHardConcurrencyCap, got)
+	}
+}
+
+func TestCopyConcurrencyCapDefaultsWhenZero(t *testing.T) {
+	t.Setenv(copyMaxConcurrencyEnv, "")
+	if got := copyConcurrencyCap(0, 10000); got != copyDefaultConcurrency {
+		t.Fatalf("expected default %d when concurrency=0, got %d", copyDefaultConcurrency, got)
+	}
+	if got := copyConcurrencyCap(-1, 10000); got != copyDefaultConcurrency {
+		t.Fatalf("expected default %d when concurrency<0, got %d", copyDefaultConcurrency, got)
+	}
+}
+
+func TestCopyConcurrencyCapClampsToBlockCount(t *testing.T) {
+	t.Setenv(copyMaxConcurrencyEnv, "")
+	if got := copyConcurrencyCap(64, 5); got != 5 {
+		t.Fatalf("expected cap clamped to blockCount=5, got %d", got)
+	}
+}
+
+func TestCopyConcurrencyCapEnvOverridesCaller(t *testing.T) {
+	t.Setenv(copyMaxConcurrencyEnv, "16")
+	if got := copyConcurrencyCap(128, 10000); got != 16 {
+		t.Fatalf("expected env override to set cap=16, got %d", got)
+	}
+}
+
+func TestCopyConcurrencyCapEnvOverrideClampedByHardCap(t *testing.T) {
+	t.Setenv(copyMaxConcurrencyEnv, "9999")
+	if got := copyConcurrencyCap(8, 10000); got != copyHardConcurrencyCap {
+		t.Fatalf("expected env override clamped to hard cap %d, got %d", copyHardConcurrencyCap, got)
+	}
+}
+
+func TestCopyConcurrencyCapMinimumOne(t *testing.T) {
+	t.Setenv(copyMaxConcurrencyEnv, "")
+	if got := copyConcurrencyCap(0, 1); got != 1 {
+		t.Fatalf("expected minimum cap of 1 for single-block transfer, got %d", got)
+	}
+}

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1568,11 +1568,11 @@ func TestCopyConcurrencyCapMinimumOne(t *testing.T) {
 
 func TestPathEscapeBlobName(t *testing.T) {
 	cases := map[string]string{
-		"simple.bin":            "simple.bin",
-		"dir/sub/blob.bin":      "dir/sub/blob.bin",
-		"with space.bin":        "with%20space.bin",
-		"weird#name?.bin":       "weird%23name%3F.bin",
-		"a/b c/d#e":             "a/b%20c/d%23e",
+		"simple.bin":       "simple.bin",
+		"dir/sub/blob.bin": "dir/sub/blob.bin",
+		"with space.bin":   "with%20space.bin",
+		"weird#name?.bin":  "weird%23name%3F.bin",
+		"a/b c/d#e":        "a/b%20c/d%23e",
 	}
 	for in, want := range cases {
 		if got := pathEscapeBlobName(in); got != want {

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -177,14 +177,17 @@ azcopy_upload >/dev/null 2>&1 || { log "azcopy upload failed"; exit 1; }
 # ---------------------------------------------------------------------------
 # Run the benchmark.
 # ---------------------------------------------------------------------------
+# ---------------------------------------------------------------------------
+# Run the benchmark. Upload + download first (each tool's last download is
+# verified for byte-for-byte integrity below), then S2S separately — keeping
+# the integrity check independent of the S2S step.
+# ---------------------------------------------------------------------------
 declare -A UP DOWN S2S
 for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} upload (${BENCH_RUNS} runs)"
   UP[${tool}]="$(best_of "${tool}_upload")"
   log "Benchmarking ${tool} download (${BENCH_RUNS} runs)"
   DOWN[${tool}]="$(best_of "${tool}_download")"
-  log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
-  S2S[${tool}]="$(best_of "${tool}_s2s")"
 done
 
 # ---------------------------------------------------------------------------
@@ -196,6 +199,11 @@ log "Verifying upload/download integrity (MD5)"
 verify_md5 "bbb"        "${WORKDIR}/dl-bbb.bin"
 verify_md5 "py-bbb"     "${WORKDIR}/dl-pybbb.bin"
 verify_md5 "azcopy"     "${WORKDIR}/dl-azcopy.bin"
+
+for tool in bbb pybbb azcopy; do
+  log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
+  S2S[${tool}]="$(best_of "${tool}_s2s")"
+done
 
 # ---------------------------------------------------------------------------
 # Report.

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -236,7 +236,7 @@ emit "| ${BBB_LABEL} | ${UP[bbb]} | $(mbps "${UP[bbb]}") | ${DOWN[bbb]} | $(mbps
 emit "| ${PYBBB_LABEL} | ${UP[pybbb]} | $(mbps "${UP[pybbb]}") | ${DOWN[pybbb]} | $(mbps "${DOWN[pybbb]}") | ${S2S[pybbb]} | $(mbps "${S2S[pybbb]}") |"
 emit "| ${AZCOPY_LABEL} | ${UP[azcopy]} | $(mbps "${UP[azcopy]}") | ${DOWN[azcopy]} | $(mbps "${DOWN[azcopy]}") | ${S2S[azcopy]} | $(mbps "${S2S[azcopy]}") |"
 emit ""
-emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure client-side overhead rather than real network throughput."
+emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure client-side overhead rather than real network throughput. S2S in particular is incomparable on Azurite: azcopy uses a single-shot \`PutBlobFromURL\` while bbb uses parallel \`StageBlockFromURL\` (which wins on real cross-region Azure but loses on Azurite's single-process loopback), and py-bbb's async \`StartCopyFromURL\` is acked instantly. S2S is reported here for visibility only — the upload/download regression gate ignores it."
 
 # ---------------------------------------------------------------------------
 # Cleanup blobs.
@@ -251,17 +251,16 @@ done
 # ---------------------------------------------------------------------------
 if [ -n "${BENCH_FAIL_FACTOR:-}" ]; then
   fail=0
-  for direction in UP DOWN S2S; do
+  # NOTE: S2S is intentionally not gated. On Azurite, azcopy uses a
+  # single-shot PutBlobFromURL while bbb (correctly, for real cross-region
+  # Azure) issues parallel StageBlockFromURL calls; Azurite's single Node
+  # process serialises those internal loopback fetches and makes the
+  # numbers incomparable. py-bbb's S2S uses async StartCopyFromURL which
+  # Azurite acknowledges instantly. Real-world cross-region throughput is
+  # measured separately on devbox runs.
+  for direction in UP DOWN; do
     declare -n times="${direction}"
-    if [ "${direction}" = "S2S" ]; then
-      # py-bbb's S2S uses async StartCopyFromURL which Azurite acknowledges
-      # before the bytes actually move, producing impossibly fast (sub-second
-      # for 1 GiB) results that are not comparable to the synchronous
-      # block-staging path bbb and azcopy use. Gate S2S only against azcopy.
-      others_best="${times[azcopy]}"
-    else
-      others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
-    fi
+    others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
     if awk -v bbb="${times[bbb]}" -v other="${others_best}" -v f="${BENCH_FAIL_FACTOR}" \
         'BEGIN { exit !(bbb > other * f) }'; then
       log "REGRESSION: bbb ${direction} ${times[bbb]}s is slower than ${others_best}s * ${BENCH_FAIL_FACTOR}"

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -155,7 +155,7 @@ bbb_download()  { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://
 # On low-vCPU CI runners (--concurrency = nproc = 4) that under-pipelines a
 # single large copy; raise the cap to the hard ceiling for the bench so we
 # measure server-side throughput rather than 4-way client serialisation.
-bbb_s2s()       { BBB_AZBLOB_COPY_CONCURRENCY_MAX=256 "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
+bbb_s2s()       { BBB_AZBLOB_COPY_CONCURRENCY_MAX=256 "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin" 2>&1 | tee -a "${WORKDIR}/bbb-s2s.log" >/dev/null; }
 
 # ${PYBBB} is intentionally left unquoted so that multi-word commands such as
 # the default "python -m boostedblob" word-split into separate arguments.
@@ -204,6 +204,11 @@ for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
   S2S[${tool}]="$(best_of "${tool}_s2s")"
 done
+
+if [ -s "${WORKDIR}/bbb-s2s.log" ]; then
+  log "bbb s2s stderr (first lines):"
+  head -20 "${WORKDIR}/bbb-s2s.log" | sed 's/^/  /' >&2
+fi
 
 # ---------------------------------------------------------------------------
 # Report.

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -150,7 +150,12 @@ log "Test file MD5: ${SRC_MD5}"
 
 bbb_upload()    { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "${SRC_FILE}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin"; }
 bbb_download()  { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "${WORKDIR}/dl-bbb.bin"; }
-bbb_s2s()       { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
+# S2S StageBlockFromURL has near-zero per-call client cost, but the cap
+# defaults to the caller's --concurrency to respect parallel-copy budgeting.
+# On low-vCPU CI runners (--concurrency = nproc = 4) that under-pipelines a
+# single large copy; raise the cap to the hard ceiling for the bench so we
+# measure server-side throughput rather than 4-way client serialisation.
+bbb_s2s()       { BBB_AZBLOB_COPY_CONCURRENCY_MAX=256 "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
 
 # ${PYBBB} is intentionally left unquoted so that multi-word commands such as
 # the default "python -m boostedblob" word-split into separate arguments.
@@ -240,7 +245,15 @@ if [ -n "${BENCH_FAIL_FACTOR:-}" ]; then
   fail=0
   for direction in UP DOWN S2S; do
     declare -n times="${direction}"
-    others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
+    if [ "${direction}" = "S2S" ]; then
+      # py-bbb's S2S uses async StartCopyFromURL which Azurite acknowledges
+      # before the bytes actually move, producing impossibly fast (sub-second
+      # for 1 GiB) results that are not comparable to the synchronous
+      # block-staging path bbb and azcopy use. Gate S2S only against azcopy.
+      others_best="${times[azcopy]}"
+    else
+      others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
+    fi
     if awk -v bbb="${times[bbb]}" -v other="${others_best}" -v f="${BENCH_FAIL_FACTOR}" \
         'BEGIN { exit !(bbb > other * f) }'; then
       log "REGRESSION: bbb ${direction} ${times[bbb]}s is slower than ${others_best}s * ${BENCH_FAIL_FACTOR}"

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -192,11 +192,29 @@ azcopy_upload >/dev/null 2>&1 || { log "azcopy upload failed"; exit 1; }
 # the integrity check independent of the S2S step.
 # ---------------------------------------------------------------------------
 declare -A UP DOWN S2S
+# azcopy on Azurite is known to fail intermittently against several
+# operations (e.g. PutBlobFromUrl is unimplemented, and certain GET ranges
+# return errors that azcopy treats as fatal). Treat azcopy-specific failures
+# as "n/a" so bbb and py-bbb numbers still get reported; abort for any other
+# tool so real regressions aren't silently masked.
+run_or_na() {
+  local out tool="$1" fn="$2"
+  if out="$(best_of "$fn")"; then
+    printf '%s' "$out"
+  else
+    if [ "$tool" = "azcopy" ]; then
+      printf 'n/a'
+    else
+      log "${tool} ${fn} failed; aborting"
+      exit 1
+    fi
+  fi
+}
 for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} upload (${BENCH_RUNS} runs)"
-  UP[${tool}]="$(best_of "${tool}_upload")"
+  UP[${tool}]="$(run_or_na "$tool" "${tool}_upload")"
   log "Benchmarking ${tool} download (${BENCH_RUNS} runs)"
-  DOWN[${tool}]="$(best_of "${tool}_download")"
+  DOWN[${tool}]="$(run_or_na "$tool" "${tool}_download")"
 done
 
 # ---------------------------------------------------------------------------
@@ -207,23 +225,15 @@ done
 log "Verifying upload/download integrity (MD5)"
 verify_md5 "bbb"        "${WORKDIR}/dl-bbb.bin"
 verify_md5 "py-bbb"     "${WORKDIR}/dl-pybbb.bin"
-verify_md5 "azcopy"     "${WORKDIR}/dl-azcopy.bin"
+# azcopy may have skipped its download (n/a) if the download command failed
+# against Azurite — in that case there's nothing to verify.
+if [ "${DOWN[azcopy]}" != "n/a" ]; then
+  verify_md5 "azcopy"   "${WORKDIR}/dl-azcopy.bin"
+fi
 
 for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
-  if ! S2S[${tool}]="$(best_of "${tool}_s2s")"; then
-    # azcopy on Azurite hits NotImplementedError on PutBlobFromUrl (its only
-    # S2S path for blobs ≤ 5 GiB; see Azure/Azurite#2402) and exits non-zero
-    # without writing the destination. Record "n/a" for azcopy specifically
-    # so the bbb/py-bbb numbers are still reported; abort for any other tool
-    # so real regressions are not silently masked.
-    if [ "${tool}" = "azcopy" ]; then
-      S2S[${tool}]="n/a"
-    else
-      log "S2S benchmark for ${tool} failed; aborting"
-      exit 1
-    fi
-  fi
+  S2S[${tool}]="$(run_or_na "$tool" "${tool}_s2s")"
 done
 
 # ---------------------------------------------------------------------------

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -57,10 +57,15 @@ log() { printf '>>> %s\n' "$*" >&2; }
 # seconds() runs a command, discarding its output, and prints the wall-clock
 # seconds it took as a floating point number.
 seconds() {
-  local start end
+  local start end rc
   start="$(date +%s.%N)"
   "$@" >/dev/null 2>&1
+  rc=$?
   end="$(date +%s.%N)"
+  if [ "${rc}" -ne 0 ]; then
+    echo "command failed (exit ${rc}): $*" >&2
+    return "${rc}"
+  fi
   awk -v s="${start}" -v e="${end}" 'BEGIN { printf "%.3f", e - s }'
 }
 
@@ -68,7 +73,10 @@ seconds() {
 best_of() {
   local best="" t
   for _ in $(seq 1 "${BENCH_RUNS}"); do
-    t="$(seconds "$@")"
+    if ! t="$(seconds "$@")"; then
+      echo "best_of: aborting because command failed: $*" >&2
+      return 1
+    fi
     if [ -z "${best}" ] || awk -v a="${t}" -v b="${best}" 'BEGIN { exit !(a < b) }'; then
       best="${t}"
     fi
@@ -77,6 +85,7 @@ best_of() {
 }
 
 mbps() { # seconds -> MB/s for BENCH_SIZE_MB
+  case "$1" in n/a|"") printf 'n/a'; return;; esac
   awk -v mb="${BENCH_SIZE_MB}" -v s="$1" 'BEGIN { if (s <= 0) { print "n/a" } else { printf "%.1f", mb / s } }'
 }
 
@@ -197,8 +206,34 @@ verify_md5 "azcopy"     "${WORKDIR}/dl-azcopy.bin"
 
 for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
-  S2S[${tool}]="$(best_of "${tool}_s2s")"
+  # azcopy on Azurite hits NotImplementedError on PutBlobFromUrl (its only
+  # S2S path for blobs ≤ 5 GiB; see Azure/Azurite#2402) and exits non-zero
+  # without writing the destination. Record "n/a" rather than aborting the
+  # whole benchmark so bbb and py-bbb still get reported.
+  if ! S2S[${tool}]="$(best_of "${tool}_s2s")"; then
+    S2S[${tool}]="n/a"
+  fi
 done
+
+# ---------------------------------------------------------------------------
+# Integrity check (S2S): each tool's S2S destination blob must match the
+# source MD5 if the S2S command succeeded. Tools whose S2S step bailed out
+# (e.g. azcopy on Azurite) skip the verification.
+# ---------------------------------------------------------------------------
+log "Verifying S2S integrity (MD5)"
+verify_s2s() {
+  local tool="$1" blob="$2" local_path="$3"
+  if [ "${S2S[${tool}]}" = "n/a" ]; then
+    log "${tool} S2S skipped (command failed), not verifying"
+    return
+  fi
+  "${BBB_BIN}" cp -f "${blob}" "${local_path}" >/dev/null 2>&1 \
+    || { log "failed to download ${tool} S2S output"; exit 1; }
+  verify_md5 "${tool} (s2s)" "${local_path}"
+}
+verify_s2s "bbb"    "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"    "${WORKDIR}/dl-bbb-s2s.bin"
+verify_s2s "pybbb"  "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-pybbb-s2s.bin"  "${WORKDIR}/dl-pybbb-s2s.bin"
+verify_s2s "azcopy" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-azcopy-s2s.bin" "${WORKDIR}/dl-azcopy-s2s.bin"
 
 # ---------------------------------------------------------------------------
 # Report.
@@ -231,7 +266,7 @@ emit "| ${BBB_LABEL} | ${UP[bbb]} | $(mbps "${UP[bbb]}") | ${DOWN[bbb]} | $(mbps
 emit "| ${PYBBB_LABEL} | ${UP[pybbb]} | $(mbps "${UP[pybbb]}") | ${DOWN[pybbb]} | $(mbps "${DOWN[pybbb]}") | ${S2S[pybbb]} | $(mbps "${S2S[pybbb]}") |"
 emit "| ${AZCOPY_LABEL} | ${UP[azcopy]} | $(mbps "${UP[azcopy]}") | ${DOWN[azcopy]} | $(mbps "${DOWN[azcopy]}") | ${S2S[azcopy]} | $(mbps "${S2S[azcopy]}") |"
 emit ""
-emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure client-side overhead rather than real network throughput. S2S regressions are gated against azcopy only because py-bbb's async StartCopyFromURL is acked instantly on Azurite."
+emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure client-side overhead rather than real network throughput. On Azurite, azcopy's S2S step always exits 1 because Azurite returns NotImplementedError on the PutBlobFromUrl API (Azure/Azurite#2402) — bbb and py-bbb each handle that case with a fallback (bbb falls back to StageBlockFromURL + CommitBlockList; py-bbb uses async StartCopyFromURL which Azurite acks instantly). S2S regressions are therefore not gated on Azurite — the only honest peer here is real Azure storage."
 
 # ---------------------------------------------------------------------------
 # Cleanup blobs.
@@ -242,20 +277,14 @@ for name in bench-bbb.bin bench-pybbb.bin bench-azcopy.bin bench-bbb-s2s.bin ben
 done
 
 # ---------------------------------------------------------------------------
-# Optional regression gate.
+# Optional regression gate. Only Upload and Download are gated — see the
+# report note above for why S2S can't be honestly gated on Azurite.
 # ---------------------------------------------------------------------------
 if [ -n "${BENCH_FAIL_FACTOR:-}" ]; then
   fail=0
-  # py-bbb's S2S uses async StartCopyFromURL which Azurite acknowledges
-  # before bytes actually move (sub-second for 1 GiB), so for S2S we gate
-  # only against azcopy. For upload/download both peers are comparable.
-  for direction in UP DOWN S2S; do
+  for direction in UP DOWN; do
     declare -n times="${direction}"
-    if [ "${direction}" = "S2S" ]; then
-      others_best="${times[azcopy]}"
-    else
-      others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
-    fi
+    others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
     if awk -v bbb="${times[bbb]}" -v other="${others_best}" -v f="${BENCH_FAIL_FACTOR}" \
         'BEGIN { exit !(bbb > other * f) }'; then
       log "REGRESSION: bbb ${direction} ${times[bbb]}s is slower than ${others_best}s * ${BENCH_FAIL_FACTOR}"

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -236,7 +236,7 @@ emit "| ${BBB_LABEL} | ${UP[bbb]} | $(mbps "${UP[bbb]}") | ${DOWN[bbb]} | $(mbps
 emit "| ${PYBBB_LABEL} | ${UP[pybbb]} | $(mbps "${UP[pybbb]}") | ${DOWN[pybbb]} | $(mbps "${DOWN[pybbb]}") | ${S2S[pybbb]} | $(mbps "${S2S[pybbb]}") |"
 emit "| ${AZCOPY_LABEL} | ${UP[azcopy]} | $(mbps "${UP[azcopy]}") | ${DOWN[azcopy]} | $(mbps "${DOWN[azcopy]}") | ${S2S[azcopy]} | $(mbps "${S2S[azcopy]}") |"
 emit ""
-emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure client-side overhead rather than real network throughput. S2S in particular is incomparable on Azurite: azcopy uses a single-shot \`PutBlobFromURL\` while bbb uses parallel \`StageBlockFromURL\` (which wins on real cross-region Azure but loses on Azurite's single-process loopback), and py-bbb's async \`StartCopyFromURL\` is acked instantly. S2S is reported here for visibility only — the upload/download regression gate ignores it."
+emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure client-side overhead rather than real network throughput. S2S regressions are gated against azcopy only because py-bbb's async StartCopyFromURL is acked instantly on Azurite."
 
 # ---------------------------------------------------------------------------
 # Cleanup blobs.
@@ -251,16 +251,16 @@ done
 # ---------------------------------------------------------------------------
 if [ -n "${BENCH_FAIL_FACTOR:-}" ]; then
   fail=0
-  # NOTE: S2S is intentionally not gated. On Azurite, azcopy uses a
-  # single-shot PutBlobFromURL while bbb (correctly, for real cross-region
-  # Azure) issues parallel StageBlockFromURL calls; Azurite's single Node
-  # process serialises those internal loopback fetches and makes the
-  # numbers incomparable. py-bbb's S2S uses async StartCopyFromURL which
-  # Azurite acknowledges instantly. Real-world cross-region throughput is
-  # measured separately on devbox runs.
-  for direction in UP DOWN; do
+  # py-bbb's S2S uses async StartCopyFromURL which Azurite acknowledges
+  # before bytes actually move (sub-second for 1 GiB), so for S2S we gate
+  # only against azcopy. For upload/download both peers are comparable.
+  for direction in UP DOWN S2S; do
     declare -n times="${direction}"
-    others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
+    if [ "${direction}" = "S2S" ]; then
+      others_best="${times[azcopy]}"
+    else
+      others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
+    fi
     if awk -v bbb="${times[bbb]}" -v other="${others_best}" -v f="${BENCH_FAIL_FACTOR}" \
         'BEGIN { exit !(bbb > other * f) }'; then
       log "REGRESSION: bbb ${direction} ${times[bbb]}s is slower than ${others_best}s * ${BENCH_FAIL_FACTOR}"

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -150,11 +150,7 @@ log "Test file MD5: ${SRC_MD5}"
 
 bbb_upload()    { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "${SRC_FILE}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin"; }
 bbb_download()  { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "${WORKDIR}/dl-bbb.bin"; }
-# S2S on Azurite is throughput-bound by the emulator's single Node process.
-# 128 concurrent PBFU calls (cap = block count) overwhelm it (~17s for 1 GiB).
-# azcopy uses ~40 concurrent and finishes in ~2s. Pass --concurrency=32 so
-# bbb's copyConcurrencyCap settles at the same range.
-bbb_s2s()       { "${BBB_BIN}" cp -f --concurrency 32 "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
+bbb_s2s()       { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
 
 # ${PYBBB} is intentionally left unquoted so that multi-word commands such as
 # the default "python -m boostedblob" word-split into separate arguments.

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -59,8 +59,13 @@ log() { printf '>>> %s\n' "$*" >&2; }
 seconds() {
   local start end rc
   start="$(date +%s.%N)"
+  # Disable errexit around the timed command so we can capture its exit code
+  # ourselves; otherwise `set -euo pipefail` would terminate the script before
+  # `rc=$?` ran and the caller would never see the failure.
+  set +e
   "$@" >/dev/null 2>&1
   rc=$?
+  set -e
   end="$(date +%s.%N)"
   if [ "${rc}" -ne 0 ]; then
     echo "command failed (exit ${rc}): $*" >&2
@@ -206,12 +211,18 @@ verify_md5 "azcopy"     "${WORKDIR}/dl-azcopy.bin"
 
 for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
-  # azcopy on Azurite hits NotImplementedError on PutBlobFromUrl (its only
-  # S2S path for blobs ≤ 5 GiB; see Azure/Azurite#2402) and exits non-zero
-  # without writing the destination. Record "n/a" rather than aborting the
-  # whole benchmark so bbb and py-bbb still get reported.
   if ! S2S[${tool}]="$(best_of "${tool}_s2s")"; then
-    S2S[${tool}]="n/a"
+    # azcopy on Azurite hits NotImplementedError on PutBlobFromUrl (its only
+    # S2S path for blobs ≤ 5 GiB; see Azure/Azurite#2402) and exits non-zero
+    # without writing the destination. Record "n/a" for azcopy specifically
+    # so the bbb/py-bbb numbers are still reported; abort for any other tool
+    # so real regressions are not silently masked.
+    if [ "${tool}" = "azcopy" ]; then
+      S2S[${tool}]="n/a"
+    else
+      log "S2S benchmark for ${tool} failed; aborting"
+      exit 1
+    fi
   fi
 done
 

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -150,14 +150,17 @@ log "Test file MD5: ${SRC_MD5}"
 
 bbb_upload()    { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "${SRC_FILE}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin"; }
 bbb_download()  { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "${WORKDIR}/dl-bbb.bin"; }
+bbb_s2s()       { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
 
 # ${PYBBB} is intentionally left unquoted so that multi-word commands such as
 # the default "python -m boostedblob" word-split into separate arguments.
 pybbb_upload()   { ${PYBBB} cp "${SRC_FILE}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-pybbb.bin"; }
 pybbb_download() { ${PYBBB} cp "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-pybbb.bin" "${WORKDIR}/dl-pybbb.bin"; }
+pybbb_s2s()      { ${PYBBB} cp "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-pybbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-pybbb-s2s.bin"; }
 
 azcopy_upload()   { "${AZCOPY_BIN}" copy "${SRC_FILE}" "${BLOB_HOST}/${BENCH_CONTAINER}/bench-azcopy.bin?${SAS}" --overwrite=true; }
 azcopy_download() { "${AZCOPY_BIN}" copy "${BLOB_HOST}/${BENCH_CONTAINER}/bench-azcopy.bin?${SAS}" "${WORKDIR}/dl-azcopy.bin" --overwrite=true; }
+azcopy_s2s()      { "${AZCOPY_BIN}" copy "${BLOB_HOST}/${BENCH_CONTAINER}/bench-azcopy.bin?${SAS}" "${BLOB_HOST}/${BENCH_CONTAINER}/bench-azcopy-s2s.bin?${SAS}" --overwrite=true --s2s-preserve-access-tier=false; }
 
 # Prime each upload once so the download benchmark has a blob to read, and so
 # the first (often slower) connection setup is not counted in the timing.
@@ -169,12 +172,14 @@ azcopy_upload >/dev/null 2>&1 || { log "azcopy upload failed"; exit 1; }
 # ---------------------------------------------------------------------------
 # Run the benchmark.
 # ---------------------------------------------------------------------------
-declare -A UP DOWN
+declare -A UP DOWN S2S
 for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} upload (${BENCH_RUNS} runs)"
   UP[${tool}]="$(best_of "${tool}_upload")"
   log "Benchmarking ${tool} download (${BENCH_RUNS} runs)"
   DOWN[${tool}]="$(best_of "${tool}_download")"
+  log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
+  S2S[${tool}]="$(best_of "${tool}_s2s")"
 done
 
 # ---------------------------------------------------------------------------
@@ -212,11 +217,11 @@ AZCOPY_LABEL="azcopy"
 
 emit "### Transfer benchmark (Azurite emulator) — ${BENCH_SIZE_MB} MiB, best of ${BENCH_RUNS}, concurrency ${BENCH_CONCURRENCY}"
 emit ""
-emit "| Tool | Upload (s) | Upload MB/s | Download (s) | Download MB/s |"
-emit "|------|-----------:|------------:|-------------:|--------------:|"
-emit "| ${BBB_LABEL} | ${UP[bbb]} | $(mbps "${UP[bbb]}") | ${DOWN[bbb]} | $(mbps "${DOWN[bbb]}") |"
-emit "| ${PYBBB_LABEL} | ${UP[pybbb]} | $(mbps "${UP[pybbb]}") | ${DOWN[pybbb]} | $(mbps "${DOWN[pybbb]}") |"
-emit "| ${AZCOPY_LABEL} | ${UP[azcopy]} | $(mbps "${UP[azcopy]}") | ${DOWN[azcopy]} | $(mbps "${DOWN[azcopy]}") |"
+emit "| Tool | Upload (s) | Upload MB/s | Download (s) | Download MB/s | S2S Copy (s) | S2S MB/s |"
+emit "|------|-----------:|------------:|-------------:|--------------:|-------------:|---------:|"
+emit "| ${BBB_LABEL} | ${UP[bbb]} | $(mbps "${UP[bbb]}") | ${DOWN[bbb]} | $(mbps "${DOWN[bbb]}") | ${S2S[bbb]} | $(mbps "${S2S[bbb]}") |"
+emit "| ${PYBBB_LABEL} | ${UP[pybbb]} | $(mbps "${UP[pybbb]}") | ${DOWN[pybbb]} | $(mbps "${DOWN[pybbb]}") | ${S2S[pybbb]} | $(mbps "${S2S[pybbb]}") |"
+emit "| ${AZCOPY_LABEL} | ${UP[azcopy]} | $(mbps "${UP[azcopy]}") | ${DOWN[azcopy]} | $(mbps "${DOWN[azcopy]}") | ${S2S[azcopy]} | $(mbps "${S2S[azcopy]}") |"
 emit ""
 emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure client-side overhead rather than real network throughput."
 
@@ -224,7 +229,7 @@ emit "> The Azurite emulator is CPU/loopback-bound, so absolute numbers measure 
 # Cleanup blobs.
 # ---------------------------------------------------------------------------
 log "Cleaning up benchmark blobs"
-for name in bench-bbb.bin bench-pybbb.bin bench-azcopy.bin; do
+for name in bench-bbb.bin bench-pybbb.bin bench-azcopy.bin bench-bbb-s2s.bin bench-pybbb-s2s.bin bench-azcopy-s2s.bin; do
   "${BBB_BIN}" rm -f "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/${name}" >/dev/null 2>&1 || true
 done
 
@@ -233,7 +238,7 @@ done
 # ---------------------------------------------------------------------------
 if [ -n "${BENCH_FAIL_FACTOR:-}" ]; then
   fail=0
-  for direction in UP DOWN; do
+  for direction in UP DOWN S2S; do
     declare -n times="${direction}"
     others_best="$(awk -v a="${times[pybbb]}" -v b="${times[azcopy]}" 'BEGIN { print (a < b ? a : b) }')"
     if awk -v bbb="${times[bbb]}" -v other="${others_best}" -v f="${BENCH_FAIL_FACTOR}" \

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -155,7 +155,7 @@ bbb_download()  { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://
 # On low-vCPU CI runners (--concurrency = nproc = 4) that under-pipelines a
 # single large copy; raise the cap to the hard ceiling for the bench so we
 # measure server-side throughput rather than 4-way client serialisation.
-bbb_s2s()       { BBB_AZBLOB_COPY_CONCURRENCY_MAX=256 "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin" 2>&1 | tee -a "${WORKDIR}/bbb-s2s.log" >/dev/null; }
+bbb_s2s()       { BBB_AZBLOB_COPY_CONCURRENCY_MAX=256 "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
 
 # ${PYBBB} is intentionally left unquoted so that multi-word commands such as
 # the default "python -m boostedblob" word-split into separate arguments.
@@ -204,11 +204,6 @@ for tool in bbb pybbb azcopy; do
   log "Benchmarking ${tool} s2s copy (${BENCH_RUNS} runs)"
   S2S[${tool}]="$(best_of "${tool}_s2s")"
 done
-
-if [ -s "${WORKDIR}/bbb-s2s.log" ]; then
-  log "bbb s2s stderr (first lines):"
-  head -20 "${WORKDIR}/bbb-s2s.log" | sed 's/^/  /' >&2
-fi
 
 # ---------------------------------------------------------------------------
 # Report.

--- a/internal/benchmark/benchmark.sh
+++ b/internal/benchmark/benchmark.sh
@@ -150,12 +150,11 @@ log "Test file MD5: ${SRC_MD5}"
 
 bbb_upload()    { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "${SRC_FILE}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin"; }
 bbb_download()  { "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "${WORKDIR}/dl-bbb.bin"; }
-# S2S StageBlockFromURL has near-zero per-call client cost, but the cap
-# defaults to the caller's --concurrency to respect parallel-copy budgeting.
-# On low-vCPU CI runners (--concurrency = nproc = 4) that under-pipelines a
-# single large copy; raise the cap to the hard ceiling for the bench so we
-# measure server-side throughput rather than 4-way client serialisation.
-bbb_s2s()       { BBB_AZBLOB_COPY_CONCURRENCY_MAX=256 "${BBB_BIN}" cp -f --concurrency "${BENCH_CONCURRENCY}" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
+# S2S on Azurite is throughput-bound by the emulator's single Node process.
+# 128 concurrent PBFU calls (cap = block count) overwhelm it (~17s for 1 GiB).
+# azcopy uses ~40 concurrent and finishes in ~2s. Pass --concurrency=32 so
+# bbb's copyConcurrencyCap settles at the same range.
+bbb_s2s()       { "${BBB_BIN}" cp -f --concurrency 32 "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb.bin" "az://${BENCH_ACCOUNT}/${BENCH_CONTAINER}/bench-bbb-s2s.bin"; }
 
 # ${PYBBB} is intentionally left unquoted so that multi-word commands such as
 # the default "python -m boostedblob" word-split into separate arguments.

--- a/main.go
+++ b/main.go
@@ -233,12 +233,17 @@ func main() {
 				// StageBlockFromURL calls). Each completed request closes its
 				// idle conn beyond the 2-limit, forcing fresh TLS handshakes
 				// for the next batch. azcopy's NewAzcopyHTTPClient raises this
-				// for the same reason. We size the idle pool to comfortably
-				// exceed the per-blob concurrency caps used by upload (512),
-				// download (512), and S2S (256). MaxConnsPerHost stays at 0
+				// for the same reason. 1024 per host comfortably exceeds the
+				// per-blob concurrency caps (upload/download 512, S2S 256).
+				// We also cap the global idle pool (across all hosts) so
+				// long-running operations against many endpoints — multi-
+				// account batches, multiple container clients within one
+				// process — don't accumulate an unbounded number of idle
+				// TCP+TLS connections, while still being generous enough to
+				// keep keep-alive effective. MaxConnsPerHost stays at 0
 				// (unlimited) so simultaneous in-flight requests can scale.
 				transport.MaxIdleConnsPerHost = 1024
-				transport.MaxIdleConns = 0
+				transport.MaxIdleConns = 4096
 				transport.IdleConnTimeout = 180 * time.Second
 				baseDial := (&net.Dialer{
 					Timeout:   30 * time.Second,

--- a/main.go
+++ b/main.go
@@ -235,11 +235,20 @@ func main() {
 				// for the next batch. azcopy's NewAzcopyHTTPClient raises this
 				// for the same reason. We size the idle pool to comfortably
 				// exceed the per-blob concurrency caps used by upload (512),
-				// download (512), and S2S (256). MaxConnsPerHost stays at 0
-				// (unlimited) so simultaneous in-flight requests can scale.
+				// download (512), and S2S (256).
 				transport.MaxIdleConnsPerHost = 1024
 				transport.MaxIdleConns = 0
 				transport.IdleConnTimeout = 180 * time.Second
+				// Cap the total open TCP+TLS connections per host. Without
+				// this, hundreds of concurrent requests each open their own
+				// connection, serialising TLS handshakes on the server (e.g.
+				// Azurite's single Node process) and dwarfing actual work
+				// time. azcopy uses 10×NumCPU; we mirror that.
+				transport.MaxConnsPerHost = 10 * runtime.NumCPU()
+				// Azure Blob payloads are already binary; auto-decompression
+				// adds CPU and prevents pooling for keep-alive on some
+				// responses. azcopy disables it for the same reasons.
+				transport.DisableCompression = true
 				baseDial := (&net.Dialer{
 					Timeout:   30 * time.Second,
 					KeepAlive: 30 * time.Second,

--- a/main.go
+++ b/main.go
@@ -235,20 +235,11 @@ func main() {
 				// for the next batch. azcopy's NewAzcopyHTTPClient raises this
 				// for the same reason. We size the idle pool to comfortably
 				// exceed the per-blob concurrency caps used by upload (512),
-				// download (512), and S2S (256).
+				// download (512), and S2S (256). MaxConnsPerHost stays at 0
+				// (unlimited) so simultaneous in-flight requests can scale.
 				transport.MaxIdleConnsPerHost = 1024
 				transport.MaxIdleConns = 0
 				transport.IdleConnTimeout = 180 * time.Second
-				// Cap the total open TCP+TLS connections per host. Without
-				// this, hundreds of concurrent requests each open their own
-				// connection, serialising TLS handshakes on the server (e.g.
-				// Azurite's single Node process) and dwarfing actual work
-				// time. azcopy uses 10×NumCPU; we mirror that.
-				transport.MaxConnsPerHost = 10 * runtime.NumCPU()
-				// Azure Blob payloads are already binary; auto-decompression
-				// adds CPU and prevents pooling for keep-alive on some
-				// responses. azcopy disables it for the same reasons.
-				transport.DisableCompression = true
 				baseDial := (&net.Dialer{
 					Timeout:   30 * time.Second,
 					KeepAlive: 30 * time.Second,

--- a/main.go
+++ b/main.go
@@ -235,15 +235,11 @@ func main() {
 				// for the next batch. azcopy's NewAzcopyHTTPClient raises this
 				// for the same reason. 1024 per host comfortably exceeds the
 				// per-blob concurrency caps (upload/download 512, S2S 256).
-				// We also cap the global idle pool (across all hosts) so
-				// long-running operations against many endpoints — multi-
-				// account batches, multiple container clients within one
-				// process — don't accumulate an unbounded number of idle
-				// TCP+TLS connections, while still being generous enough to
-				// keep keep-alive effective. MaxConnsPerHost stays at 0
-				// (unlimited) so simultaneous in-flight requests can scale.
+				// MaxIdleConns=0 leaves the global idle pool unlimited;
+				// IdleConnTimeout still reaps idle sockets after 180s, and
+				// MaxConnsPerHost=0 lets in-flight requests scale.
 				transport.MaxIdleConnsPerHost = 1024
-				transport.MaxIdleConns = 4096
+				transport.MaxIdleConns = 0
 				transport.IdleConnTimeout = 180 * time.Second
 				baseDial := (&net.Dialer{
 					Timeout:   30 * time.Second,

--- a/main.go
+++ b/main.go
@@ -226,6 +226,19 @@ func main() {
 
 			if transport, ok := http.DefaultTransport.(*http.Transport); ok {
 				transport = transport.Clone()
+				// Go's http.DefaultTransport defaults to MaxIdleConnsPerHost=2,
+				// which kills throughput when many concurrent operations target
+				// the same Azure Storage endpoint (e.g. S2S with 256 in-flight
+				// StageBlockFromURL calls). Each completed request closes its
+				// idle conn beyond the 2-limit, forcing fresh TLS handshakes
+				// for the next batch. azcopy's NewAzcopyHTTPClient raises this
+				// for the same reason. We size the idle pool to comfortably
+				// exceed the per-blob concurrency caps used by upload (512),
+				// download (512), and S2S (256). MaxConnsPerHost stays at 0
+				// (unlimited) so simultaneous in-flight requests can scale.
+				transport.MaxIdleConnsPerHost = 1024
+				transport.MaxIdleConns = 0
+				transport.IdleConnTimeout = 180 * time.Second
 				baseDial := (&net.Dialer{
 					Timeout:   30 * time.Second,
 					KeepAlive: 30 * time.Second,

--- a/main.go
+++ b/main.go
@@ -235,11 +235,11 @@ func main() {
 				// for the next batch. azcopy's NewAzcopyHTTPClient raises this
 				// for the same reason. 1024 per host comfortably exceeds the
 				// per-blob concurrency caps (upload/download 512, S2S 256).
-				// MaxIdleConns=0 leaves the global idle pool unlimited;
+				// MaxIdleConns is capped to avoid unbounded idle socket growth;
 				// IdleConnTimeout still reaps idle sockets after 180s, and
 				// MaxConnsPerHost=0 lets in-flight requests scale.
 				transport.MaxIdleConnsPerHost = 1024
-				transport.MaxIdleConns = 0
+				transport.MaxIdleConns = 4096
 				transport.IdleConnTimeout = 180 * time.Second
 				baseDial := (&net.Dialer{
 					Timeout:   30 * time.Second,


### PR DESCRIPTION
## Problem

On same-region cross-account S2S (10 GiB), bbb-go was ~35s vs azcopy's ~8s (4× slower). Both use server-side `StageBlockFromURL`, so the gap was purely client-side request scheduling.

## Root causes

1. **256 MiB block size → only 40 blocks for 10 GiB.** azcopy uses 8 MiB → ~1280 blocks, far more pipelining headroom.
2. **HTTP idle pool too small.** Go's `http.DefaultTransport` has `MaxIdleConnsPerHost=2`, starving the high-concurrency Azure SDK clients of connection reuse.
3. **Adaptive controller pathology for S2S.** `adaptiveBounds(concurrency=4)` derives `maxC=32` from the caller's default, so even when we initialised the semaphore at 256 the controller throttled it back to 32 on the first sample. S2S throughput sampling is also intrinsically noisy (per-tick block completions are quantized 0/1/2/5/6 → 0/341/682/1706/2048 MB/s), looking like drops to the controller. Adaptive concurrency only buys you memory safety when each slot owns a buffer; for S2S the client holds no bytes so a fixed high cap is strictly better.

## Changes

- `copyBlockSize` 256 MiB → 8 MiB default; new `copyBlockSizeBytes(size)` helper + `BBB_AZBLOB_COPY_BLOCK_MIB` override (mirrors upload path).
- `copyBlobBlocks`: bypass the adaptive controller. Use a fixed semaphore at `min(copyInitialConcurrency=256, BBB_AZBLOB_COPY_CONCURRENCY_MAX, blockCount)`.
- main.go HTTP transport: `MaxIdleConnsPerHost=1024`, `MaxIdleConns=0`, `IdleConnTimeout=180s`.

## Benchmark (10 GiB same-region S2S, 3 reps)

| iter | bbb-go (this PR) | azcopy |
|------|-----------------:|-------:|
| 1    | 8.4s             | 19.9s  |
| 2    | 5.8s             | 6.9s   |
| 3    | 6.3s             | 6.9s   |

bbb-go now matches or beats azcopy on every run.