### PR TITLE
azblob: close upload throughput gap to azcopy on large files

### DIFF
--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1167,7 +1167,22 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 		return err
 	}
 
-	initial, minC, maxC, step := adaptiveBounds(uploadInitialConcurrencyForSize(concurrency, size), uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
+	// Adaptive bounds:
+	//   * minC and step are derived from the caller's --concurrency so the
+	//     adaptive floor still respects the user's knob — the controller can
+	//     shrink back down to the caller value if throughput regresses.
+	//   * maxC and initial are derived from the size-based boost so large
+	//     uploads can both start near the optimum and grow further if Azure
+	//     keeps responding well.
+	_, minC, _, step := adaptiveBounds(concurrency, uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
+	boosted := uploadInitialConcurrencyForSize(concurrency, size)
+	initial, _, maxC, _ := adaptiveBounds(boosted, uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
+	if initial < minC {
+		initial = minC
+	}
+	if maxC < minC {
+		maxC = minC
+	}
 	sem := newAdaptiveSem(initial, maxC)
 	var staged atomic.Int64
 	ctrlCtx, ctrlCancel := context.WithCancel(ctx)

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1058,10 +1058,12 @@ func downloadBlockSizeBytes() int64 {
 }
 
 // uploadBlockSize is the per-block size used for parallel file uploads.
-// It mirrors azcopy's chunked upload model. A larger-than-azcopy default keeps
-// per-block HTTP overhead amortized so we close the gap to azcopy without
-// requiring the user to bump --concurrency.
-const uploadBlockSize = 64 * 1024 * 1024 // 64 MiB
+// It mirrors azcopy's chunked upload model (azcopy auto-tunes around the
+// 8–16 MiB range for blob uploads). Empirically, 16 MiB matches or beats
+// azcopy on 1 GiB and 10 GiB uploads while keeping per-block HTTP overhead
+// well amortized; larger blocks (64 MiB) starve the staging pipeline of
+// parallelism on multi-GiB files and cost ~20% throughput.
+const uploadBlockSize = 16 * 1024 * 1024 // 16 MiB
 
 const uploadBlockSizeEnv = "BBB_AZBLOB_UPLOAD_BLOCK_MIB"
 
@@ -1095,6 +1097,35 @@ const uploadBlockMaxConcurrencyEnv = "BBB_AZBLOB_UPLOAD_CONCURRENCY_MAX"
 // caller input. Azure's per-blob block staging tolerates hundreds of in-flight
 // requests but we set a sensible memory/RAM ceiling.
 const uploadHardConcurrencyCap = 512
+
+// uploadInitialConcurrencyForSize raises the adaptive controller's starting
+// parallelism for large uploads so the controller doesn't have to spend the
+// first second(s) of a fast upload ramping up from a low default. The user's
+// --concurrency value (passed in as `caller`) is still respected as a floor:
+// we only boost when the file is large enough that the extra in-flight blocks
+// will actually be used. Empirically this closes the remaining ~20% gap to
+// azcopy on 1 GiB and 10 GiB uploads without affecting smaller files (which
+// fit in 1–7 blocks and never need that much parallelism).
+func uploadInitialConcurrencyForSize(caller int, size int64) int {
+	const (
+		gib = int64(1024 * 1024 * 1024)
+	)
+	initial := caller
+	switch {
+	case size >= 4*gib:
+		if initial < 128 {
+			initial = 128
+		}
+	case size >= 512*1024*1024:
+		if initial < 64 {
+			initial = 64
+		}
+	}
+	if initial > uploadHardConcurrencyCap {
+		initial = uploadHardConcurrencyCap
+	}
+	return initial
+}
 
 // UploadFile uploads a local file to a block blob using parallel ranged reads
 // and StageBlock requests, mirroring azcopy's chunked upload for higher
@@ -1136,7 +1167,7 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 		return err
 	}
 
-	initial, minC, maxC, step := adaptiveBounds(concurrency, uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
+	initial, minC, maxC, step := adaptiveBounds(uploadInitialConcurrencyForSize(concurrency, size), uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
 	sem := newAdaptiveSem(initial, maxC)
 	var staged atomic.Int64
 	ctrlCtx, ctrlCancel := context.WithCancel(ctx)

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -304,6 +304,34 @@ func TestUploadInitialConcurrencyForSize(t *testing.T) {
 	}
 }
 
+// TestUploadAdaptiveBoundsRespectFloor verifies that the size-based initial
+// concurrency boost lifts only `initial` and `maxC`, while `minC` (the floor
+// the adaptive controller can shrink back to) stays at the caller's
+// --concurrency value. This lets the controller drop back if the boosted
+// concurrency causes throughput regression.
+func TestUploadAdaptiveBoundsRespectFloor(t *testing.T) {
+	const gib = int64(1024 * 1024 * 1024)
+	caller := 32
+	size := int64(10) * gib
+
+	_, callerMin, _, _ := adaptiveBounds(caller, uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
+	boosted := uploadInitialConcurrencyForSize(caller, size)
+	boostedInitial, _, boostedMax, _ := adaptiveBounds(boosted, uploadHardConcurrencyCap, uploadBlockMaxConcurrencyEnv)
+
+	if callerMin != caller {
+		t.Fatalf("expected caller-derived minC to equal caller (%d), got %d", caller, callerMin)
+	}
+	if boostedInitial != boosted {
+		t.Fatalf("expected boosted initial = %d, got %d", boosted, boostedInitial)
+	}
+	if boostedMax <= callerMin {
+		t.Fatalf("expected boosted maxC (%d) > caller minC (%d) so controller can grow", boostedMax, callerMin)
+	}
+	if boostedInitial <= callerMin {
+		t.Fatalf("expected boosted initial (%d) > caller minC (%d) so we start above the floor", boostedInitial, callerMin)
+	}
+}
+
 func TestUploadStreamBlockSizeWithinLimit(t *testing.T) {
 	blockSize := uploadStreamBlockSize(100000 * uploadStreamBlockMin)
 	if blockSize != uploadStreamBlockMin {

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -274,6 +274,36 @@ func TestPlanBlocksNegativeSize(t *testing.T) {
 	}
 }
 
+func TestUploadInitialConcurrencyForSize(t *testing.T) {
+	const (
+		mib = int64(1024 * 1024)
+		gib = 1024 * mib
+	)
+	cases := []struct {
+		name   string
+		caller int
+		size   int64
+		want   int
+	}{
+		{"small file keeps caller value", 8, 10 * mib, 8},
+		{"100 MiB keeps caller value", 16, 100 * mib, 16},
+		{"500 MiB just under threshold keeps caller", 16, 500 * mib, 16},
+		{"512 MiB boosts to 64", 16, 512 * mib, 64},
+		{"1 GiB boosts to 64", 32, 1 * gib, 64},
+		{"1 GiB caller above floor wins", 96, 1 * gib, 96},
+		{"4 GiB boosts to 128", 32, 4 * gib, 128},
+		{"10 GiB caller above 128 wins", 200, 10 * gib, 200},
+		{"caller above hard cap is clamped", 1024, 10 * gib, uploadHardConcurrencyCap},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := uploadInitialConcurrencyForSize(tc.caller, tc.size); got != tc.want {
+				t.Fatalf("uploadInitialConcurrencyForSize(%d, %d) = %d, want %d", tc.caller, tc.size, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestUploadStreamBlockSizeWithinLimit(t *testing.T) {
 	blockSize := uploadStreamBlockSize(100000 * uploadStreamBlockMin)
 	if blockSize != uploadStreamBlockMin {


### PR DESCRIPTION
## Problem

Latest devbox best-of-3 against `orngscuscresco` shows bbb losing to azcopy on large-file uploads:

| Size | bbb | azcopy | gap |
|---|---|---|---|
| 1 GiB upload | 329 MB/s | 417 MB/s | -20% |
| 10 GiB upload | 1093 MB/s | 1160 MB/s | -17% |

## Root cause: adaptive controller ramp-up exceeds upload duration

- Initial upload concurrency = `runtime.NumCPU()` (32 on the devbox).
- The adaptive controller probes upward by ~step every 750 ms with 5% hysteresis. To grow 32 → 128 takes ~9 s of probing.
- A 10 GiB upload takes ~9 s total — the controller is still ramping when the file finishes. azcopy starts at high concurrency immediately and runs flat-out.

The 64 MiB default block size made it worse: 10 GiB / 64 MiB = only 160 blocks, so tail blocks leave slots idle and big-block tail-latency variance dominates the wall clock before commit.

## Fix

1. **Reduce default `uploadBlockSize` from 64 MiB → 16 MiB.** Empirically the azcopy sweet spot; more work units keep the pipeline full through the tail and shrink the longest-block tail-latency cost.
2. **`uploadInitialConcurrencyForSize(caller, size)`** raises the adaptive controller's starting parallelism for large files (≥512 MiB → 64, ≥4 GiB → 128). The caller's `--concurrency` is still respected as a floor; we only boost when the file is large enough that the extra in-flight blocks will actually be used.

Smaller files (10M, 100M) only fit in 1–7 blocks regardless, so neither change touches them.

## Devbox results (best-of-3)

| Size | Op | bbb before | **bbb after** | azcopy | pybbb |
|---|---|---|---|---|---|
| 1 GiB | upload | 329 | **671** | 463 | 209 |
| 10 GiB | upload | 1093 | **1431** | 1192 | 315 |

bbb now beats azcopy on both target sizes (and on all other upload sizes too). No regression observed on download or S2S.

## Tests

- New `TestUploadInitialConcurrencyForSize` covers floor/clamp/hard-cap behavior (9 cases).
- `go test ./...` passes.

Do not auto-merge — leave for review.