### PR TITLE
benchmark: don't cap bbb S2S concurrency on real Azure (fixes 4× S2S regression)

### DIFF
--- a/internal/benchmark/benchmark_test.go
+++ b/internal/benchmark/benchmark_test.go
@@ -497,10 +497,12 @@ func TestBenchmark(t *testing.T) {
 	}
 	// azcopy: keep its own log quiet.
 	t.Setenv("AZCOPY_LOG_LEVEL", "ERROR")
-	// bbb's S2S code path defaults to 256 parallel StageBlockFromURL calls,
-	// which overwhelms Azurite's single-process loopback emulator. Cap it to the
-	// same concurrency the other tools use so the benchmark stays stable.
-	if os.Getenv("BBB_AZBLOB_COPY_CONCURRENCY_MAX") == "" {
+	// On Azurite (single-process loopback emulator) bbb's S2S default of
+	// 256 parallel StageBlockFromURL calls overwhelms the emulator, so cap
+	// it to the benchmark concurrency to keep the run stable. Do NOT cap on
+	// real Azure: the 256-way fan-out is critical for cross-account S2S
+	// throughput (without it, 10 GiB takes ~30s instead of ~7s).
+	if !cfg.external && os.Getenv("BBB_AZBLOB_COPY_CONCURRENCY_MAX") == "" {
 		t.Setenv("BBB_AZBLOB_COPY_CONCURRENCY_MAX", strconv.Itoa(cfg.concurrency))
 	}
 


### PR DESCRIPTION
## Problem

After #98 landed, the new `internal/benchmark` tool showed a 3-4× S2S regression on real Azure that did **not** reproduce with standalone `bbb cp`:

| Tool   | 10 GiB S2S (before) |
|--------|---------------------|
| bbb (standalone) | ~7 s |
| **bbb (via bench tool)** | **~30 s** |
| azcopy | ~8 s |

Same binary, same blobs, only the harness differs.

## Root cause

`benchmark_test.go` unconditionally sets `BBB_AZBLOB_COPY_CONCURRENCY_MAX=cfg.concurrency` (=32 by default) for **all** runs:

```go
// bbb's S2S code path defaults to 256 parallel StageBlockFromURL calls,
// which overwhelms Azurite's single-process loopback emulator. Cap it to the
// same concurrency the other tools use so the benchmark stays stable.
if os.Getenv("BBB_AZBLOB_COPY_CONCURRENCY_MAX") == "" {
    t.Setenv("BBB_AZBLOB_COPY_CONCURRENCY_MAX", strconv.Itoa(cfg.concurrency))
}
```

The comment is correct — the cap is an Azurite stability workaround — but the guard is missing `!cfg.external`. On real Azure this clamps S2S `StageBlockFromURL` fan-out from 256 → 32, an 8× drop in pipeline depth, which translates to the ~4× wall-time regression.

Diagnosed via an env-gated `BBB_AZBLOB_S2S_TRACE` instrumentation (not in this PR):

- bench:       `stage done blocks=1250 cap=32  stage_ms=28332`
- standalone:  `stage done blocks=1250 cap=256 stage_ms=7298`

## Fix

Gate the env-set on `!cfg.external` so the cap applies only to Azurite. Real-Azure benches now use bbb's `copyDefaultConcurrency = 256` like standalone `bbb cp` does. Standalone bbb is unaffected because nothing else sets the env var.

## Verification

Same devbox, src=orngscuscresco, dst=orngtransfer, 10 GiB, best of 3:

| Tool   | Upload (s) | Download (s) | **S2S (s)** |
|--------|-----------:|-------------:|------------:|
| bbb    | 6.47       | 9.51         | **7.09**    |
| pybbb  | 33.21      | 18.76        | 20.94       |
| azcopy | 8.17       | 10.34        | **6.88**    |

bbb S2S is back at parity with azcopy (~7 s vs ~7 s) — was 30.36 s vs 8.71 s before this change.

`go build ./...` and `go test ./internal/benchmark/` pass.
