### PR TITLE
Support server-side copy for hf:// -> az:// sync

### DIFF
--- a/README.md
+++ b/README.md
@@ -506,6 +506,12 @@ Unidirectional sync: copies new and updated files from source to destination.
 bbb sync [flags] src dst
 ```
 
+> **Server-side copy:** For Azure→Azure and Hugging Face→Azure syncs, `bbb`
+> instructs Azure Blob Storage to pull each file directly from the source
+> (Az→Az) or from the Hugging Face CDN URL (HF→Az), so the data never transits
+> the client. If a Hugging Face file can't be copied server-side, `bbb`
+> automatically falls back to streaming it through the client.
+
 | Flag | Description |
 |------|-------------|
 | `--taskfile FILE` | Batch task file with one `src dst` pair per line; use `-` for stdin |

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -27,6 +27,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/sdk/azidentity"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/bloberror"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/blockblob"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
 	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/sas"
@@ -1731,11 +1732,17 @@ func isInvalidBlobOrBlock(err error) bool {
 
 // clearUncommittedBlocks deletes the destination blob to discard any
 // uncommitted blocks poisoning it, so a subsequent staged upload starts from a
-// clean slate. Best effort: a missing blob (nothing to clear) is not an error.
+// clean slate. Best effort: a missing blob (BlobNotFound — nothing to clear) is
+// expected and ignored silently; any other delete error is logged at Warn for
+// diagnosis but not returned, since the caller retries the upload regardless.
 func clearUncommittedBlocks(ctx context.Context, client *azblob.Client, ap AzurePath) {
 	bbc := client.ServiceClient().NewContainerClient(ap.Container).NewBlockBlobClient(ap.Blob)
 	if _, err := bbc.Delete(ctx, nil); err != nil {
-		slog.Debug("clearUncommittedBlocks: delete returned error (ignored)", "dst", ap.String(), "err", err)
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.ErrorCode == string(bloberror.BlobNotFound) {
+			return
+		}
+		slog.Warn("clearUncommittedBlocks: delete failed (ignored)", "dst", ap.String(), "err", err)
 	}
 }
 

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1134,7 +1134,26 @@ func uploadInitialConcurrencyForSize(caller int, size int64) int {
 // improving, up to uploadHardConcurrencyCap (overridable via
 // BBB_AZBLOB_UPLOAD_CONCURRENCY_MAX). The optional onProgress callback
 // receives the cumulative number of bytes staged.
+// UploadFile uploads a local file to a block blob using an adaptive parallel
+// StageBlock + CommitBlockList pass.
+//
+// If staging is rejected with InvalidBlobOrBlock — which happens when the
+// destination retains uncommitted blocks of a different block-ID length from a
+// prior aborted upload — the poisoned blob is cleared and the upload is retried
+// once from a clean slate.
 func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency int, onProgress func(int64)) error {
+	err := uploadFileOnce(ctx, ap, file, concurrency, onProgress)
+	if err != nil && isInvalidBlobOrBlock(err) {
+		slog.Warn("upload hit InvalidBlobOrBlock; clearing stale uncommitted blocks and retrying", "dst", ap.String())
+		if client, cerr := getAzBlobClient(ctx, ap.Account); cerr == nil {
+			clearUncommittedBlocks(ctx, client, ap)
+		}
+		err = uploadFileOnce(ctx, ap, file, concurrency, onProgress)
+	}
+	return err
+}
+
+func uploadFileOnce(ctx context.Context, ap AzurePath, file *os.File, concurrency int, onProgress func(int64)) error {
 	if ap.Blob == "" || strings.HasSuffix(ap.Blob, "/") {
 		return errors.New("cannot upload to directory-like path")
 	}
@@ -1250,7 +1269,7 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 	close(done)
 
 	if firstErr != nil {
-		return fmt.Errorf("put failed: %v", firstErr)
+		return fmt.Errorf("put failed: %w", firstErr)
 	}
 	if _, err := blockBlobClient.CommitBlockList(ctx, blockIDs, nil); err != nil {
 		return fmt.Errorf("commit block list failed: %w", err)
@@ -1698,6 +1717,28 @@ func planBlocks(totalSize int64, defaultBlockSize int64, maxBlocks int64) (block
 	return blockSize, ids, nil
 }
 
+// isInvalidBlobOrBlock reports whether err is an Azure "InvalidBlobOrBlock"
+// (HTTP 400) response. This occurs when a block blob has pre-existing
+// uncommitted blocks whose IDs differ in length from the ones being staged —
+// e.g. left behind by a prior aborted upload that used a different block
+// size/ID scheme. Azure requires every block ID for a blob to be the same
+// length, so staging new blocks on such a "poisoned" blob is rejected until the
+// stale uncommitted blocks are cleared.
+func isInvalidBlobOrBlock(err error) bool {
+	var respErr *azcore.ResponseError
+	return errors.As(err, &respErr) && respErr.ErrorCode == "InvalidBlobOrBlock"
+}
+
+// clearUncommittedBlocks deletes the destination blob to discard any
+// uncommitted blocks poisoning it, so a subsequent staged upload starts from a
+// clean slate. Best effort: a missing blob (nothing to clear) is not an error.
+func clearUncommittedBlocks(ctx context.Context, client *azblob.Client, ap AzurePath) {
+	bbc := client.ServiceClient().NewContainerClient(ap.Container).NewBlockBlobClient(ap.Blob)
+	if _, err := bbc.Delete(ctx, nil); err != nil {
+		slog.Debug("clearUncommittedBlocks: delete returned error (ignored)", "dst", ap.String(), "err", err)
+	}
+}
+
 // CopyProgress is called during server-side copy with the number of
 // bytes copied so far and the total size in bytes.
 type CopyProgress func(copied, total int64)
@@ -1940,11 +1981,28 @@ func CopyBlobFromURLServerSide(ctx context.Context, dst AzurePath, sourceURL str
 
 // copyBlobBlocks copies a blob using parallel StageBlockFromURL + CommitBlockList.
 //
+// If staging is rejected with InvalidBlobOrBlock — which happens when the
+// destination retains uncommitted blocks of a different block-ID length from a
+// prior aborted upload — the poisoned blob is cleared and the copy is retried
+// once from a clean slate.
+func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, copySource, sourceAuth string, totalSize int64, concurrency int, onProgress CopyProgress) error {
+	err := copyBlobBlocksOnce(ctx, client, dst, copySource, sourceAuth, totalSize, concurrency, onProgress)
+	if err != nil && isInvalidBlobOrBlock(err) {
+		slog.Warn("server-side copy hit InvalidBlobOrBlock; clearing stale uncommitted blocks and retrying", "dst", dst.String())
+		clearUncommittedBlocks(ctx, client, dst)
+		err = copyBlobBlocksOnce(ctx, client, dst, copySource, sourceAuth, totalSize, concurrency, onProgress)
+	}
+	return err
+}
+
+// copyBlobBlocksOnce performs a single parallel StageBlockFromURL +
+// CommitBlockList pass.
+//
 // When sourceAuth is non-empty, it is forwarded as
 // x-ms-copy-source-authorization on every StageBlockFromURL request so the
 // destination uses OAuth to read the source instead of relying on
 // SAS-embedded credentials (~8× faster intra-region on real Azure).
-func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, copySource, sourceAuth string, totalSize int64, concurrency int, onProgress CopyProgress) error {
+func copyBlobBlocksOnce(ctx context.Context, client *azblob.Client, dst AzurePath, copySource, sourceAuth string, totalSize int64, concurrency int, onProgress CopyProgress) error {
 	blockBlobClient := client.ServiceClient().NewContainerClient(dst.Container).NewBlockBlobClient(dst.Blob)
 
 	// Plan blocks and generate IDs.

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1141,6 +1141,12 @@ func uploadInitialConcurrencyForSize(caller int, size int64) int {
 // prior aborted upload — the poisoned blob is cleared and the upload is retried
 // once from a clean slate.
 func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency int, onProgress func(int64)) error {
+	// Guard against non-monotonic progress across the self-heal retry below,
+	// which restarts the byte counter from zero.
+	if onProgress != nil {
+		var last atomic.Int64
+		onProgress = monotonicProgress(&last, onProgress)
+	}
 	err := uploadFileOnce(ctx, ap, file, concurrency, onProgress)
 	if err != nil && isInvalidBlobOrBlock(err) {
 		slog.Warn("upload hit InvalidBlobOrBlock; clearing stale uncommitted blocks and retrying", "dst", ap.String())
@@ -1174,7 +1180,7 @@ func uploadFileOnce(ctx context.Context, ap AzurePath, file *os.File, concurrenc
 	if size == 0 {
 		_, err := blockBlobClient.CommitBlockList(ctx, nil, nil)
 		if err != nil {
-			return fmt.Errorf("put failed: %v", err)
+			return fmt.Errorf("put failed: %w", err)
 		}
 		if onProgress != nil {
 			onProgress(0)
@@ -1536,7 +1542,7 @@ func Upload(ctx context.Context, ap AzurePath, data []byte) error {
 	blobClient := client.ServiceClient().NewContainerClient(ap.Container).NewBlockBlobClient(ap.Blob)
 	_, err = blobClient.UploadBuffer(ctx, data, nil)
 	if err != nil {
-		return fmt.Errorf("put failed: %v", err)
+		return fmt.Errorf("put failed: %w", err)
 	}
 	return nil
 }
@@ -1672,7 +1678,7 @@ func UploadStream(ctx context.Context, ap AzurePath, reader io.Reader, concurren
 		Concurrency: concurrency,
 	})
 	if err != nil {
-		return fmt.Errorf("put failed: %v", err)
+		return fmt.Errorf("put failed: %w", err)
 	}
 	return nil
 }
@@ -1748,6 +1754,11 @@ func clearUncommittedBlocks(ctx context.Context, client *azblob.Client, ap Azure
 
 // CopyProgress is called during server-side copy with the number of
 // bytes copied so far and the total size in bytes.
+//
+// It may be invoked concurrently from multiple StageBlockFromURL goroutines,
+// so implementations must be goroutine-safe. The copied value passed to a
+// single CopyProgress is already clamped to be monotonically non-decreasing,
+// even across an internal InvalidBlobOrBlock self-heal retry.
 type CopyProgress func(copied, total int64)
 
 func CopyBlobServerSide(ctx context.Context, src AzurePath, dst AzurePath, concurrency int, sizeHint int64, onProgress CopyProgress) error {
@@ -1993,6 +2004,14 @@ func CopyBlobFromURLServerSide(ctx context.Context, dst AzurePath, sourceURL str
 // prior aborted upload — the poisoned blob is cleared and the copy is retried
 // once from a clean slate.
 func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, copySource, sourceAuth string, totalSize int64, concurrency int, onProgress CopyProgress) error {
+	// Guard against non-monotonic progress across the self-heal retry below,
+	// which restarts the byte counter from zero.
+	if onProgress != nil {
+		orig := onProgress
+		var last atomic.Int64
+		emit := monotonicProgress(&last, func(copied int64) { orig(copied, totalSize) })
+		onProgress = func(copied, _ int64) { emit(copied) }
+	}
 	err := copyBlobBlocksOnce(ctx, client, dst, copySource, sourceAuth, totalSize, concurrency, onProgress)
 	if err != nil && isInvalidBlobOrBlock(err) {
 		slog.Warn("server-side copy hit InvalidBlobOrBlock; clearing stale uncommitted blocks and retrying", "dst", dst.String())

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1145,6 +1145,10 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 	// which restarts the byte counter from zero.
 	if onProgress != nil {
 		var last atomic.Int64
+		// Start below zero so a legitimate 0-byte upload (empty blob) still
+		// delivers its onProgress(0); monotonicProgress otherwise drops any
+		// value not strictly greater than the initial count.
+		last.Store(-1)
 		onProgress = monotonicProgress(&last, onProgress)
 	}
 	err := uploadFileOnce(ctx, ap, file, concurrency, onProgress)

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1975,15 +1975,22 @@ func CopyBlobFromURLServerSide(ctx context.Context, dst AzurePath, sourceURL str
 	if sourceURL == "" {
 		return errors.New("empty source URL")
 	}
-	if size < 0 {
-		return errors.New("unknown source size")
-	}
 	if concurrency < 1 {
 		concurrency = 1
 	}
 	client, err := getAzBlobClient(ctx, dst.Account)
 	if err != nil {
 		return err
+	}
+	if size < 0 {
+		// Unknown source size: the block-staging path needs a size up front
+		// to plan block IDs, but Azure's StartCopyFromURL performs the entire
+		// transfer server-side without one (progress is polled from the
+		// service). Route straight to the async copy instead of failing, so
+		// sources lacking a reliable Content-Length/X-Linked-Size still get a
+		// server-side copy rather than a client-side streaming fallback.
+		slog.Debug("source size unknown; using async StartCopyFromURL for server-side copy", "dst", dst.String())
+		return copyBlobAsync(ctx, client, dst, sourceURL, size, onProgress)
 	}
 	// The external source URL already carries its own auth (a signed CDN
 	// query string), so no x-ms-copy-source-authorization header is sent.
@@ -2193,7 +2200,10 @@ func copyBlobAsync(ctx context.Context, client *azblob.Client, dst AzurePath, co
 	if copyStatus != blob.CopyStatusTypeSuccess {
 		return fmt.Errorf("copy failed with status %s", copyStatus)
 	}
-	if onProgress != nil {
+	// Emit a final 100% signal only when the total is known; with an unknown
+	// (negative) size, the last poll's reportCopyProgress already delivered
+	// the service-reported total.
+	if onProgress != nil && totalSize >= 0 {
 		onProgress(totalSize, totalSize)
 	}
 	return nil

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1733,7 +1733,7 @@ func planBlocks(totalSize int64, defaultBlockSize int64, maxBlocks int64) (block
 // stale uncommitted blocks are cleared.
 func isInvalidBlobOrBlock(err error) bool {
 	var respErr *azcore.ResponseError
-	return errors.As(err, &respErr) && respErr.ErrorCode == "InvalidBlobOrBlock"
+	return errors.As(err, &respErr) && respErr.ErrorCode == string(bloberror.InvalidBlobOrBlock)
 }
 
 // clearUncommittedBlocks deletes the destination blob to discard any

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -2013,6 +2013,10 @@ func copyBlobBlocks(ctx context.Context, client *azblob.Client, dst AzurePath, c
 	if onProgress != nil {
 		orig := onProgress
 		var last atomic.Int64
+		// Seed below zero so a 0-byte copy's onProgress(0, 0) is still
+		// delivered; monotonicProgress otherwise drops any value not strictly
+		// greater than the initial count.
+		last.Store(-1)
 		emit := monotonicProgress(&last, func(copied int64) { orig(copied, totalSize) })
 		onProgress = func(copied, _ int64) { emit(copied) }
 	}

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1134,8 +1134,6 @@ func uploadInitialConcurrencyForSize(caller int, size int64) int {
 // improving, up to uploadHardConcurrencyCap (overridable via
 // BBB_AZBLOB_UPLOAD_CONCURRENCY_MAX). The optional onProgress callback
 // receives the cumulative number of bytes staged.
-// UploadFile uploads a local file to a block blob using an adaptive parallel
-// StageBlock + CommitBlockList pass.
 //
 // If staging is rejected with InvalidBlobOrBlock — which happens when the
 // destination retains uncommitted blocks of a different block-ID length from a
@@ -1153,6 +1151,8 @@ func UploadFile(ctx context.Context, ap AzurePath, file *os.File, concurrency in
 	return err
 }
 
+// uploadFileOnce performs a single adaptive parallel StageBlock +
+// CommitBlockList upload pass, without any InvalidBlobOrBlock self-heal.
 func uploadFileOnce(ctx context.Context, ap AzurePath, file *os.File, concurrency int, onProgress func(int64)) error {
 	if ap.Blob == "" || strings.HasSuffix(ap.Blob, "/") {
 		return errors.New("cannot upload to directory-like path")

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1900,6 +1900,44 @@ func copyBlockSizeBytes(size int64) int64 {
 	return block
 }
 
+// CopyBlobFromURLServerSide copies an external, publicly-readable HTTP(S)
+// source URL directly into an Azure blob without streaming the bytes through
+// this client. It is used for cross-backend server-side copy (e.g. Hugging
+// Face → Azure), where the source URL is a public/signed CDN URL. size must be
+// the exact source size in bytes.
+func CopyBlobFromURLServerSide(ctx context.Context, dst AzurePath, sourceURL string, size int64, concurrency int, onProgress CopyProgress) error {
+	if dst.Blob == "" || strings.HasSuffix(dst.Blob, "/") {
+		return errors.New("destination path is directory-like")
+	}
+	if sourceURL == "" {
+		return errors.New("empty source URL")
+	}
+	if size < 0 {
+		return errors.New("unknown source size")
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+	client, err := getAzBlobClient(ctx, dst.Account)
+	if err != nil {
+		return err
+	}
+	// The external source URL already carries its own auth (a signed CDN
+	// query string), so no x-ms-copy-source-authorization header is sent.
+	err = copyBlobBlocks(ctx, client, dst, sourceURL, "", size, concurrency, onProgress)
+	if err != nil {
+		// StageBlockFromURL (Put Block From URL) returns 501 in emulators
+		// like Azurite. Fall back to the async StartCopyFromURL approach.
+		var respErr *azcore.ResponseError
+		if errors.As(err, &respErr) && respErr.StatusCode == 501 {
+			slog.Debug("StageBlockFromURL not supported, falling back to StartCopyFromURL", "dst", dst.String())
+			return copyBlobAsync(ctx, client, dst, sourceURL, size, onProgress)
+		}
+		return err
+	}
+	return nil
+}
+
 // copyBlobBlocks copies a blob using parallel StageBlockFromURL + CommitBlockList.
 //
 // When sourceAuth is non-empty, it is forwarded as

--- a/internal/azblob/azblob.go
+++ b/internal/azblob/azblob.go
@@ -1966,8 +1966,13 @@ func copyBlockSizeBytes(size int64) int64 {
 // CopyBlobFromURLServerSide copies an external, publicly-readable HTTP(S)
 // source URL directly into an Azure blob without streaming the bytes through
 // this client. It is used for cross-backend server-side copy (e.g. Hugging
-// Face → Azure), where the source URL is a public/signed CDN URL. size must be
-// the exact source size in bytes.
+// Face → Azure), where the source URL is a public/signed CDN URL.
+//
+// size is the exact source size in bytes when known; pass a negative value
+// when the size is unknown. A known size uses the parallel StageBlockFromURL +
+// CommitBlockList path (which must plan block IDs up front); an unknown size
+// routes to Azure's async StartCopyFromURL, which transfers the whole blob
+// server-side without a pre-known size.
 func CopyBlobFromURLServerSide(ctx context.Context, dst AzurePath, sourceURL string, size int64, concurrency int, onProgress CopyProgress) error {
 	if dst.Blob == "" || strings.HasSuffix(dst.Blob, "/") {
 		return errors.New("destination path is directory-like")

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1286,6 +1286,25 @@ func TestMonotonicProgressNilCallback(t *testing.T) {
 	}
 }
 
+func TestMonotonicProgressDeliversLeadingZero(t *testing.T) {
+	// UploadFile seeds last=-1 so a 0-byte upload's onProgress(0) is still
+	// delivered instead of being swallowed as a non-increasing value.
+	var last atomic.Int64
+	last.Store(-1)
+	var calls []int64
+	emit := monotonicProgress(&last, func(v int64) { calls = append(calls, v) })
+
+	emit(0) // leading zero: must be delivered when seeded at -1
+	emit(0) // duplicate: dropped
+
+	if len(calls) != 1 || calls[0] != 0 {
+		t.Fatalf("expected exactly one 0 delivery, got %v", calls)
+	}
+	if got := last.Load(); got != 0 {
+		t.Fatalf("expected last=0, got %d", got)
+	}
+}
+
 func TestMonotonicProgressFiltersStale(t *testing.T) {
 	var last atomic.Int64
 	var calls []int64

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1654,3 +1654,75 @@ func TestCopySourceOAuthURLNoDoubleSlash(t *testing.T) {
 		t.Fatalf("source URL = %q, want %q", srcURL, want)
 	}
 }
+
+// TestCopyBlobFromURLServerSideSelfHealsInvalidBlobOrBlock verifies that when
+// StageBlockFromURL is rejected with InvalidBlobOrBlock (a destination blob
+// poisoned by stale uncommitted blocks of a different ID length), the copy
+// path deletes the poisoned blob and retries the stage+commit exactly once,
+// ultimately succeeding.
+func TestCopyBlobFromURLServerSideSelfHealsInvalidBlobOrBlock(t *testing.T) {
+	prev := sharedHTTPClient.Load()
+	t.Cleanup(func() { sharedHTTPClient.Store(prev) })
+
+	account := "selfhealcheck"
+	blobClientCache.Delete(account)
+	t.Cleanup(func() { blobClientCache.Delete(account) })
+
+	// Shared-key credential bypasses token acquisition network calls.
+	t.Setenv("BBB_AZBLOB_ACCOUNTKEY", "dGVzdGtleQ==") // base64("testkey")
+
+	var stageCalls, commitCalls, deleteCalls atomic.Int64
+	var deleted atomic.Bool
+
+	nopBody := func() io.ReadCloser { return io.NopCloser(strings.NewReader("")) }
+	SetHTTPTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		comp := req.URL.Query().Get("comp")
+		switch {
+		case req.Method == http.MethodDelete:
+			deleteCalls.Add(1)
+			deleted.Store(true)
+			return &http.Response{StatusCode: 202, Header: http.Header{}, Body: nopBody(), Request: req}, nil
+		case req.Method == http.MethodPut && comp == "block":
+			stageCalls.Add(1)
+			if !deleted.Load() {
+				// Poisoned: reject staging with InvalidBlobOrBlock until the
+				// blob is cleared.
+				return &http.Response{
+					StatusCode: 400,
+					Header:     http.Header{"X-Ms-Error-Code": []string{string(bloberror.InvalidBlobOrBlock)}},
+					Body:       io.NopCloser(strings.NewReader(`<?xml version="1.0"?><Error><Code>InvalidBlobOrBlock</Code><Message>poisoned</Message></Error>`)),
+					Request:    req,
+				}, nil
+			}
+			return &http.Response{StatusCode: 201, Header: http.Header{}, Body: nopBody(), Request: req}, nil
+		case req.Method == http.MethodPut && comp == "blocklist":
+			commitCalls.Add(1)
+			return &http.Response{StatusCode: 201, Header: http.Header{}, Body: nopBody(), Request: req}, nil
+		default:
+			return &http.Response{StatusCode: 201, Header: http.Header{}, Body: nopBody(), Request: req}, nil
+		}
+	}))
+	t.Cleanup(func() { SetHTTPTransport(nil) })
+
+	dst := AzurePath{Account: account, Container: "c", Blob: "poisoned.bin"}
+	var lastCopied, lastTotal int64
+	err := CopyBlobFromURLServerSide(context.Background(), dst,
+		"https://source.example/blob?sig=abc", 8, 1, func(copied, total int64) {
+			lastCopied, lastTotal = copied, total
+		})
+	if err != nil {
+		t.Fatalf("CopyBlobFromURLServerSide should self-heal and succeed, got: %v", err)
+	}
+	if got := deleteCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 delete (self-heal), got %d", got)
+	}
+	if got := stageCalls.Load(); got < 2 {
+		t.Fatalf("expected at least 2 stage attempts (initial failure + retry), got %d", got)
+	}
+	if got := commitCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 successful commit after retry, got %d", got)
+	}
+	if lastCopied != 8 || lastTotal != 8 {
+		t.Fatalf("expected final progress 8/8, got %d/%d", lastCopied, lastTotal)
+	}
+}

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -1745,3 +1745,64 @@ func TestCopyBlobFromURLServerSideSelfHealsInvalidBlobOrBlock(t *testing.T) {
 		t.Fatalf("expected final progress 8/8, got %d/%d", lastCopied, lastTotal)
 	}
 }
+
+// TestCopyBlobFromURLServerSideUnknownSizeUsesAsyncCopy verifies that when the
+// source size is unknown (negative), the server-side copy does not hard-fail
+// but instead routes to the async StartCopyFromURL path, which does not need a
+// pre-known size.
+func TestCopyBlobFromURLServerSideUnknownSizeUsesAsyncCopy(t *testing.T) {
+	prev := sharedHTTPClient.Load()
+	t.Cleanup(func() { sharedHTTPClient.Store(prev) })
+
+	account := "asynccopycheck"
+	blobClientCache.Delete(account)
+	t.Cleanup(func() { blobClientCache.Delete(account) })
+
+	t.Setenv("BBB_AZBLOB_ACCOUNTKEY", "dGVzdGtleQ==") // base64("testkey")
+
+	var startCopyCalls, getPropsCalls, stageCalls atomic.Int64
+	nopBody := func() io.ReadCloser { return io.NopCloser(strings.NewReader("")) }
+	SetHTTPTransport(roundTripFunc(func(req *http.Request) (*http.Response, error) {
+		switch {
+		case req.Method == http.MethodPut && req.URL.Query().Get("comp") == "block":
+			stageCalls.Add(1)
+			return &http.Response{StatusCode: 201, Header: http.Header{}, Body: nopBody(), Request: req}, nil
+		case req.Method == http.MethodPut && req.URL.Query().Get("comp") == "":
+			// StartCopyFromURL: PUT to the blob with no comp param.
+			startCopyCalls.Add(1)
+			h := http.Header{}
+			h.Set("x-ms-copy-status", "success")
+			return &http.Response{StatusCode: 202, Header: h, Body: nopBody(), Request: req}, nil
+		case req.Method == http.MethodHead:
+			getPropsCalls.Add(1)
+			h := http.Header{}
+			h.Set("x-ms-copy-status", "success")
+			h.Set("x-ms-copy-progress", "1024/1024")
+			return &http.Response{StatusCode: 200, Header: h, Body: nopBody(), Request: req}, nil
+		default:
+			return &http.Response{StatusCode: 201, Header: http.Header{}, Body: nopBody(), Request: req}, nil
+		}
+	}))
+	t.Cleanup(func() { SetHTTPTransport(nil) })
+
+	dst := AzurePath{Account: account, Container: "c", Blob: "unknown-size.bin"}
+	var lastCopied, lastTotal int64
+	err := CopyBlobFromURLServerSide(context.Background(), dst,
+		"https://source.example/blob?sig=abc", -1, 4, func(copied, total int64) {
+			lastCopied, lastTotal = copied, total
+		})
+	if err != nil {
+		t.Fatalf("expected unknown-size copy to succeed via async path, got: %v", err)
+	}
+	if got := startCopyCalls.Load(); got != 1 {
+		t.Fatalf("expected exactly 1 StartCopyFromURL, got %d", got)
+	}
+	if got := stageCalls.Load(); got != 0 {
+		t.Fatalf("expected no StageBlockFromURL calls for unknown-size copy, got %d", got)
+	}
+	// Progress is reported from the service (1024/1024), not from the unknown
+	// caller-provided size.
+	if lastCopied != 1024 || lastTotal != 1024 {
+		t.Fatalf("expected service-reported progress 1024/1024, got %d/%d", lastCopied, lastTotal)
+	}
+}

--- a/internal/bbbfs/az.go
+++ b/internal/bbbfs/az.go
@@ -244,6 +244,47 @@ func (azFS) CopyServerSide(ctx context.Context, src, dst string, concurrency int
 	return azblob.CopyBlobServerSide(ctx, srcAP, dstAP, concurrency, sizeHint, onProgress)
 }
 
+// CopyFromURLServerSide copies a public source URL directly into an Azure blob
+// server-side, without streaming bytes through this process.
+func (azFS) CopyFromURLServerSide(ctx context.Context, sourceURL, dst string, size int64, concurrency int, onProgress CopyProgress) error {
+	dstAP, err := azblob.Parse(dst)
+	if err != nil {
+		return err
+	}
+	return azblob.CopyBlobFromURLServerSide(ctx, dstAP, sourceURL, size, concurrency, onProgress)
+}
+
+// UploadReader ingests an arbitrary reader into an Azure blob by first spooling
+// it to a temporary file and then using the size-aware parallel block-staging
+// upload path (16 MiB blocks), which is more robust on real Azure than the
+// SDK's streaming uploader (whose 256 MiB block floor can trigger
+// InvalidBlobOrBlock on some accounts). onProgress, when non-nil, receives the
+// cumulative number of bytes uploaded.
+func (azFS) UploadReader(ctx context.Context, dst string, r io.Reader, concurrency int, onProgress func(copied int64)) error {
+	ap, err := azblob.Parse(dst)
+	if err != nil {
+		return err
+	}
+	tmp, err := os.CreateTemp("", "bbb-upload-*")
+	if err != nil {
+		return err
+	}
+	tmpName := tmp.Name()
+	defer func() {
+		_ = tmp.Close()
+		_ = os.Remove(tmpName)
+	}()
+	if _, err := io.Copy(tmp, r); err != nil {
+		return err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		return err
+	}
+	// UploadFile reports cumulative bytes uploaded, matching onProgress's
+	// contract, so it is forwarded directly.
+	return azblob.UploadFile(ctx, ap, tmp, concurrency, onProgress)
+}
+
 func (azFS) ListStream(ctx context.Context, p string, fn func(Entry) error) error {
 	ap, err := azblob.Parse(p)
 	if err != nil {

--- a/internal/bbbfs/az.go
+++ b/internal/bbbfs/az.go
@@ -7,6 +7,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -254,16 +255,44 @@ func (azFS) CopyFromURLServerSide(ctx context.Context, sourceURL, dst string, si
 	return azblob.CopyBlobFromURLServerSide(ctx, dstAP, sourceURL, size, concurrency, onProgress)
 }
 
+// uploadSpoolSlots bounds how many UploadReader calls may hold a full
+// spooled-to-disk temp file at once. The streaming fallback (used when a
+// server-side copy fails) spools the entire source to local temp storage
+// before uploading; without a cap, N concurrent sync workers would each spool
+// a full file, multiplying peak disk usage by N and failing syncs on
+// disk-constrained hosts. The cap is overridable via BBB_AZ_UPLOAD_SPOOL_MAX
+// (positive integer); it defaults to 4.
+var uploadSpoolSlots = make(chan struct{}, uploadSpoolMax())
+
+func uploadSpoolMax() int {
+	if v := os.Getenv("BBB_AZ_UPLOAD_SPOOL_MAX"); v != "" {
+		if n, err := strconv.Atoi(v); err == nil && n > 0 {
+			return n
+		}
+	}
+	return 4
+}
+
 // UploadReader ingests an arbitrary reader into an Azure blob by first spooling
 // it to a temporary file and then using the size-aware parallel block-staging
 // upload path (16 MiB blocks), which is more robust on real Azure than the
 // SDK's streaming uploader (whose 256 MiB block floor can trigger
 // InvalidBlobOrBlock on some accounts). onProgress, when non-nil, receives the
 // cumulative number of bytes uploaded.
+//
+// Concurrent spooling is bounded by uploadSpoolSlots so that many parallel
+// sync workers falling back to this path cannot exhaust local temp disk.
 func (azFS) UploadReader(ctx context.Context, dst string, r io.Reader, concurrency int, onProgress func(copied int64)) error {
 	ap, err := azblob.Parse(dst)
 	if err != nil {
 		return err
+	}
+	// Bound concurrent temp-file spooling to cap peak local disk usage.
+	select {
+	case uploadSpoolSlots <- struct{}{}:
+		defer func() { <-uploadSpoolSlots }()
+	case <-ctx.Done():
+		return ctx.Err()
 	}
 	tmp, err := os.CreateTemp("", "bbb-upload-*")
 	if err != nil {

--- a/internal/bbbfs/bbbfs_test.go
+++ b/internal/bbbfs/bbbfs_test.go
@@ -125,3 +125,20 @@ func TestRegisterAzAccountRolesNonAzIgnored(t *testing.T) {
 		t.Fatalf("expected SRC for myacct, got %q (ok=%v)", role, ok)
 	}
 }
+
+func TestUploadSpoolMax(t *testing.T) {
+	cases := map[string]int{
+		"":       4, // default
+		"0":      4, // non-positive ignored
+		"-3":     4, // negative ignored
+		"notint": 4, // unparseable ignored
+		"1":      1,
+		"16":     16,
+	}
+	for in, want := range cases {
+		t.Setenv("BBB_AZ_UPLOAD_SPOOL_MAX", in)
+		if got := uploadSpoolMax(); got != want {
+			t.Fatalf("uploadSpoolMax() with %q = %d, want %d", in, got, want)
+		}
+	}
+}

--- a/internal/bbbfs/hf.go
+++ b/internal/bbbfs/hf.go
@@ -29,6 +29,16 @@ func (hfFS) Read(ctx context.Context, path string) (io.ReadCloser, error) {
 	return hf.DownloadStream(ctx, hp)
 }
 
+// CopySourceURL resolves a public, redirect-followed download URL and size for
+// a Hugging Face file so another backend can copy it server-side.
+func (hfFS) CopySourceURL(ctx context.Context, path string) (string, int64, error) {
+	hp, err := hf.Parse(path)
+	if err != nil {
+		return "", 0, err
+	}
+	return hf.ResolveDirectURL(ctx, hp)
+}
+
 func (hfFS) Write(ctx context.Context, path string, r io.Reader) error {
 	return ErrWriteUnsupported
 }

--- a/internal/bbbfs/ops.go
+++ b/internal/bbbfs/ops.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -251,6 +252,64 @@ func CopyServerSide(ctx context.Context, src, dst string, concurrency int, sizeH
 		return sc.CopyServerSide(ctx, src, dst, concurrency, sizeHint, onProgress)
 	}
 	return errors.New("server-side copy not supported")
+}
+
+// copySourceURLProvider is implemented by backends that can produce a public,
+// redirect-resolved URL for a file, suitable for another backend to copy from
+// server-side.
+type copySourceURLProvider interface {
+	CopySourceURL(ctx context.Context, path string) (url string, size int64, err error)
+}
+
+// urlServerSideCopier is implemented by backends that can copy directly from a
+// public source URL into themselves server-side (e.g. Azure copy-from-URL).
+type urlServerSideCopier interface {
+	CopyFromURLServerSide(ctx context.Context, sourceURL, dst string, size int64, concurrency int, onProgress CopyProgress) error
+}
+
+// CanCopyServerSideFromURL returns true when src can produce a public source
+// URL and dst can copy from a URL server-side (e.g. Hugging Face → Azure).
+func CanCopyServerSideFromURL(src, dst string) bool {
+	_, srcOK := Resolve(src).(copySourceURLProvider)
+	_, dstOK := Resolve(dst).(urlServerSideCopier)
+	return srcOK && dstOK
+}
+
+// CopyServerSideFromURL resolves a public source URL from src and asks dst to
+// copy from it server-side, without streaming the bytes through this process.
+func CopyServerSideFromURL(ctx context.Context, src, dst string, concurrency int, onProgress CopyProgress) error {
+	srcFS := Resolve(src)
+	sp, ok := srcFS.(copySourceURLProvider)
+	if !ok {
+		return errors.New("source does not support server-side copy URLs")
+	}
+	dstFS := Resolve(dst)
+	uc, ok := dstFS.(urlServerSideCopier)
+	if !ok {
+		return errors.New("destination does not support server-side copy from URL")
+	}
+	sourceURL, size, err := sp.CopySourceURL(ctx, src)
+	if err != nil {
+		return err
+	}
+	return uc.CopyFromURLServerSide(ctx, sourceURL, dst, size, concurrency, onProgress)
+}
+
+// readerUploader is implemented by backends that can ingest a reader using a
+// more reliable upload path than streaming Write (e.g. Azure spools to a temp
+// file and uses size-aware parallel block staging).
+type readerUploader interface {
+	UploadReader(ctx context.Context, dst string, r io.Reader, concurrency int, onProgress func(copied int64)) error
+}
+
+// UploadReader writes r to dst using the backend's most reliable upload path,
+// falling back to a plain streaming Write when the backend does not implement
+// readerUploader. onProgress, when non-nil, receives cumulative bytes uploaded.
+func UploadReader(ctx context.Context, dst string, r io.Reader, concurrency int, onProgress func(copied int64)) error {
+	if u, ok := Resolve(dst).(readerUploader); ok {
+		return u.UploadReader(ctx, dst, r, concurrency, onProgress)
+	}
+	return Resolve(dst).Write(ctx, dst, r)
 }
 
 // streamLister is an optional FS extension for streaming list.

--- a/internal/hf/hf.go
+++ b/internal/hf/hf.go
@@ -171,13 +171,18 @@ func ResolveDirectURL(ctx context.Context, p Path) (directURL string, size int64
 	if err != nil {
 		return "", 0, err
 	}
-	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolveURL, nil)
+	// Use HEAD (not a ranged GET) so we resolve redirects and read headers
+	// without downloading the file through this client. Critically, we must
+	// NOT send a Range header: Hugging Face's Xet/CloudFront bridge bakes the
+	// requested Range into the signed URL's policy (ByteRange condition), which
+	// would restrict the resulting URL to that exact range and cause Azure's
+	// server-side copy (StageBlockFromURL / CopyFromURL) to fail with 403
+	// CannotVerifyCopySource. A rangeless HEAD yields a signed URL that accepts
+	// arbitrary Range requests, which is required for block-based S2S copy.
+	req, err := http.NewRequestWithContext(ctx, http.MethodHead, resolveURL, nil)
 	if err != nil {
 		return "", 0, err
 	}
-	// Request only the first byte so we resolve redirects and read headers
-	// without downloading the whole file through this client.
-	req.Header.Set("Range", "bytes=0-0")
 	resp, err := doRequest(req)
 	if err != nil {
 		return "", 0, err

--- a/internal/hf/hf.go
+++ b/internal/hf/hf.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/url"
 	"path"
+	"strconv"
 	"strings"
 	"sync/atomic"
 )
@@ -159,6 +160,80 @@ type downloadReadCloser struct {
 // Size reports the HTTP Content-Length or -1 if unknown.
 func (d downloadReadCloser) Size() int64 {
 	return d.size
+}
+
+// ResolveDirectURL resolves the final, redirect-followed download URL for a
+// Hugging Face file along with its size in bytes. The returned URL is a public
+// (typically signed CDN) URL suitable for server-side copy by another service
+// (e.g. Azure Blob's copy-from-URL). Size is -1 when unknown.
+func ResolveDirectURL(ctx context.Context, p Path) (directURL string, size int64, err error) {
+	resolveURL, err := p.URL()
+	if err != nil {
+		return "", 0, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, resolveURL, nil)
+	if err != nil {
+		return "", 0, err
+	}
+	// Request only the first byte so we resolve redirects and read headers
+	// without downloading the whole file through this client.
+	req.Header.Set("Range", "bytes=0-0")
+	resp, err := doRequest(req)
+	if err != nil {
+		return "", 0, err
+	}
+	defer func() {
+		_ = resp.Body.Close()
+	}()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return "", 0, fmt.Errorf("hf resolve failed: %w", &HTTPStatusError{StatusCode: resp.StatusCode, Status: resp.Status})
+	}
+	directURL = resolveURL
+	if resp.Request != nil && resp.Request.URL != nil {
+		directURL = resp.Request.URL.String()
+	}
+	size = resolvedSize(resp)
+	return directURL, size, nil
+}
+
+// resolvedSize derives the total file size from a resolve response, preferring
+// the Content-Range total (present on a ranged 206), then Hugging Face's
+// X-Linked-Size header, then Content-Length. Returns -1 when unknown.
+func resolvedSize(resp *http.Response) int64 {
+	if total := parseContentRangeTotal(resp.Header.Get("Content-Range")); total >= 0 {
+		return total
+	}
+	if v := resp.Header.Get("X-Linked-Size"); v != "" {
+		if n, err := strconv.ParseInt(v, 10, 64); err == nil {
+			return n
+		}
+	}
+	if resp.ContentLength >= 0 && resp.Request != nil && resp.Request.Header.Get("Range") == "" {
+		return resp.ContentLength
+	}
+	return -1
+}
+
+// parseContentRangeTotal extracts the total size from a Content-Range header
+// value of the form "bytes 0-0/12345". Returns -1 when the total is unknown
+// or unparseable.
+func parseContentRangeTotal(v string) int64 {
+	if v == "" {
+		return -1
+	}
+	idx := strings.LastIndex(v, "/")
+	if idx < 0 {
+		return -1
+	}
+	total := strings.TrimSpace(v[idx+1:])
+	if total == "" || total == "*" {
+		return -1
+	}
+	n, err := strconv.ParseInt(total, 10, 64)
+	if err != nil {
+		return -1
+	}
+	return n
 }
 
 // ListFiles retrieves repo files for directory-like paths.

--- a/internal/hf/hf_test.go
+++ b/internal/hf/hf_test.go
@@ -56,17 +56,21 @@ func TestResolveDirectURL(t *testing.T) {
 	const cdnURL = "https://cdn-lfs.huggingface.co/repo/model.bin?sig=abc"
 	original := doRequest
 	doRequest = func(req *http.Request) (*http.Response, error) {
-		if req.Header.Get("Range") != "bytes=0-0" {
-			t.Fatalf("expected range header, got %q", req.Header.Get("Range"))
+		if req.Method != http.MethodHead {
+			t.Fatalf("expected HEAD request, got %q", req.Method)
 		}
-		hdr := make(http.Header)
-		hdr.Set("Content-Range", "bytes 0-0/1048576")
-		finalReq, _ := http.NewRequest(http.MethodGet, cdnURL, nil)
+		// A Range header would range-lock the signed CDN URL and break
+		// server-side copy, so it must not be sent.
+		if r := req.Header.Get("Range"); r != "" {
+			t.Fatalf("expected no range header, got %q", r)
+		}
+		finalReq, _ := http.NewRequest(http.MethodHead, cdnURL, nil)
 		return &http.Response{
-			StatusCode: http.StatusPartialContent,
-			Body:       io.NopCloser(strings.NewReader("x")),
-			Header:     hdr,
-			Request:    finalReq,
+			StatusCode:    http.StatusOK,
+			Body:          io.NopCloser(strings.NewReader("")),
+			Header:        make(http.Header),
+			ContentLength: 1048576,
+			Request:       finalReq,
 		}, nil
 	}
 	t.Cleanup(func() { doRequest = original })

--- a/internal/hf/hf_test.go
+++ b/internal/hf/hf_test.go
@@ -51,3 +51,71 @@ func TestListFilesAPIEndpoint(t *testing.T) {
 		})
 	}
 }
+
+func TestResolveDirectURL(t *testing.T) {
+	const cdnURL = "https://cdn-lfs.huggingface.co/repo/model.bin?sig=abc"
+	original := doRequest
+	doRequest = func(req *http.Request) (*http.Response, error) {
+		if req.Header.Get("Range") != "bytes=0-0" {
+			t.Fatalf("expected range header, got %q", req.Header.Get("Range"))
+		}
+		hdr := make(http.Header)
+		hdr.Set("Content-Range", "bytes 0-0/1048576")
+		finalReq, _ := http.NewRequest(http.MethodGet, cdnURL, nil)
+		return &http.Response{
+			StatusCode: http.StatusPartialContent,
+			Body:       io.NopCloser(strings.NewReader("x")),
+			Header:     hdr,
+			Request:    finalReq,
+		}, nil
+	}
+	t.Cleanup(func() { doRequest = original })
+
+	url, size, err := ResolveDirectURL(context.Background(), Path{Repo: "owner/repo", File: "model.bin"})
+	if err != nil {
+		t.Fatalf("ResolveDirectURL failed: %v", err)
+	}
+	if url != cdnURL {
+		t.Fatalf("unexpected url: %s", url)
+	}
+	if size != 1048576 {
+		t.Fatalf("unexpected size: %d", size)
+	}
+}
+
+func TestResolveDirectURLXLinkedSize(t *testing.T) {
+	original := doRequest
+	doRequest = func(req *http.Request) (*http.Response, error) {
+		hdr := make(http.Header)
+		hdr.Set("X-Linked-Size", "42")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Body:       io.NopCloser(strings.NewReader("")),
+			Header:     hdr,
+			Request:    req,
+		}, nil
+	}
+	t.Cleanup(func() { doRequest = original })
+
+	_, size, err := ResolveDirectURL(context.Background(), Path{Repo: "owner/repo", File: "a.txt"})
+	if err != nil {
+		t.Fatalf("ResolveDirectURL failed: %v", err)
+	}
+	if size != 42 {
+		t.Fatalf("unexpected size: %d", size)
+	}
+}
+
+func TestParseContentRangeTotal(t *testing.T) {
+	cases := map[string]int64{
+		"bytes 0-0/1048576": 1048576,
+		"bytes 0-99/*":      -1,
+		"":                  -1,
+		"garbage":           -1,
+	}
+	for in, want := range cases {
+		if got := parseContentRangeTotal(in); got != want {
+			t.Fatalf("parseContentRangeTotal(%q)=%d want %d", in, got, want)
+		}
+	}
+}

--- a/main.go
+++ b/main.go
@@ -2400,14 +2400,19 @@ func cmdSyncPaths(ctx context.Context, dry, del, quiet bool, exclude string, con
 					copyBar.SetTotal(total)
 					copyBar.render(copied)
 				})
-				if copyBar != nil {
-					copyBar.Finish()
-				}
 				if err == nil {
+					if copyBar != nil {
+						copyBar.Finish()
+					}
 					if !quiet {
 						lockedPrintf("Copied %s -> %s\n", srcChild, dstChild)
 					}
 					return nil
+				}
+				// Copy failed: tear the bar down without rendering it as a
+				// completed 100% line before falling back to streaming.
+				if copyBar != nil {
+					copyBar.Abort()
 				}
 				// Server-side copy failed — commonly because Azure cannot read
 				// the Hugging Face source URL (403 CannotVerifyCopySource) for

--- a/main.go
+++ b/main.go
@@ -2426,6 +2426,11 @@ func cmdSyncPaths(ctx context.Context, dry, del, quiet bool, exclude string, con
 					upBar = newStreamingProgressBar(path.Base(sPath), false, true)
 					if upBar != nil {
 						upBar.byteSized = true
+						if sized, ok := reader.(interface{ Size() int64 }); ok {
+							if total := sized.Size(); total > 0 {
+								upBar.SetTotal(total)
+							}
+						}
 					}
 				}
 				uerr := withReadCloser(reader, func(r io.Reader) error {

--- a/main.go
+++ b/main.go
@@ -2415,6 +2415,7 @@ func cmdSyncPaths(ctx context.Context, dry, del, quiet bool, exclude string, con
 				// short-lived. Fall back to streaming the file through this
 				// client via a temp file + size-aware block upload.
 				slog.Debug("HF→Az server-side copy failed, falling back to streaming", "src", srcChild, "error", err)
+				lockedFprintf(os.Stderr, "sync: %s: server-side copy failed (%v); falling back to streaming\n", sPath, err)
 				reader, rerr := bbbfs.Resolve(srcChild).Read(ctx, srcChild)
 				if rerr != nil {
 					lockedFprintf(os.Stderr, "sync: %s: %v\n", sPath, rerr)

--- a/main.go
+++ b/main.go
@@ -2380,6 +2380,75 @@ func cmdSyncPaths(ctx context.Context, dry, del, quiet bool, exclude string, con
 				}
 				return nil
 			}
+			// HF→Az: prefer server-side copy (Azure pulls directly from the
+			// Hugging Face CDN URL) so bytes never transit this client. Fall
+			// back to streaming Read+Write on failure.
+			if srcHF && dstAz {
+				var copyBar *progressBar
+				if !quiet {
+					copyBar = newStreamingProgressBar(path.Base(sPath), false, true)
+					if copyBar != nil {
+						copyBar.byteSized = true
+					}
+				}
+				err := bbbfs.CopyServerSideFromURL(ctx, srcChild, dstChild, blockConcurrency, func(copied, total int64) {
+					if total <= 0 || copyBar == nil {
+						return
+					}
+					atomicMax(&copyBar.bytesDone, copied)
+					atomicMax(&copyBar.done, copied)
+					copyBar.SetTotal(total)
+					copyBar.render(copied)
+				})
+				if copyBar != nil {
+					copyBar.Finish()
+				}
+				if err == nil {
+					if !quiet {
+						lockedPrintf("Copied %s -> %s\n", srcChild, dstChild)
+					}
+					return nil
+				}
+				// Server-side copy failed — commonly because Azure cannot read
+				// the Hugging Face source URL (403 CannotVerifyCopySource) for
+				// LFS/Xet-backed files whose signed CDN URLs are IP-bound or
+				// short-lived. Fall back to streaming the file through this
+				// client via a temp file + size-aware block upload.
+				slog.Debug("HF→Az server-side copy failed, falling back to streaming", "src", srcChild, "error", err)
+				reader, rerr := bbbfs.Resolve(srcChild).Read(ctx, srcChild)
+				if rerr != nil {
+					lockedFprintf(os.Stderr, "sync: %s: %v\n", sPath, rerr)
+					return fmt.Errorf("sync: %s: %w", sPath, rerr)
+				}
+				var upBar *progressBar
+				if !quiet {
+					upBar = newStreamingProgressBar(path.Base(sPath), false, true)
+					if upBar != nil {
+						upBar.byteSized = true
+					}
+				}
+				uerr := withReadCloser(reader, func(r io.Reader) error {
+					return bbbfs.UploadReader(ctx, dstChild, r, blockConcurrency, func(copied int64) {
+						if upBar == nil {
+							return
+						}
+						atomicMax(&upBar.bytesDone, copied)
+						atomicMax(&upBar.done, copied)
+						upBar.render(copied)
+					})
+				})
+				if upBar != nil {
+					upBar.Finish()
+				}
+				if uerr != nil {
+					lockedFprintf(os.Stderr, "sync: %s: %v\n", sPath, uerr)
+					return fmt.Errorf("sync: %s: %w", sPath, uerr)
+				}
+				if !quiet {
+					lockedPrintf("Copied %s -> %s\n", srcChild, dstChild)
+				}
+				return nil
+			}
 			reader, err := bbbfs.Resolve(srcChild).Read(ctx, srcChild)
 			if err != nil {
 				lockedFprintf(os.Stderr, "sync: %s: %v\n", sPath, err)

--- a/main.go
+++ b/main.go
@@ -2450,12 +2450,15 @@ func cmdSyncPaths(ctx context.Context, dry, del, quiet bool, exclude string, con
 						upBar.render(copied)
 					})
 				})
-				if upBar != nil {
-					upBar.Finish()
-				}
 				if uerr != nil {
+					if upBar != nil {
+						upBar.Abort()
+					}
 					lockedFprintf(os.Stderr, "sync: %s: %v\n", sPath, uerr)
 					return fmt.Errorf("sync: %s: %w", sPath, uerr)
+				}
+				if upBar != nil {
+					upBar.Finish()
 				}
 				if !quiet {
 					lockedPrintf("Copied %s -> %s\n", srcChild, dstChild)

--- a/main.go
+++ b/main.go
@@ -2415,7 +2415,9 @@ func cmdSyncPaths(ctx context.Context, dry, del, quiet bool, exclude string, con
 				// short-lived. Fall back to streaming the file through this
 				// client via a temp file + size-aware block upload.
 				slog.Debug("HF→Az server-side copy failed, falling back to streaming", "src", srcChild, "error", err)
-				lockedFprintf(os.Stderr, "sync: %s: server-side copy failed (%v); falling back to streaming\n", sPath, err)
+				if !quiet {
+					lockedFprintf(os.Stderr, "sync: %s: server-side copy failed (%v); falling back to streaming\n", sPath, err)
+				}
 				reader, rerr := bbbfs.Resolve(srcChild).Read(ctx, srcChild)
 				if rerr != nil {
 					lockedFprintf(os.Stderr, "sync: %s: %v\n", sPath, rerr)

--- a/main_test.go
+++ b/main_test.go
@@ -1697,3 +1697,25 @@ func TestDNSPinCacheReturnsSameIP(t *testing.T) {
 		}
 	}
 }
+
+func TestProgressBarAbortDoesNotMarkComplete(t *testing.T) {
+	p := &progressBar{}
+	p.total.Store(1000)
+	p.done.Store(400)
+	p.lastTotal.Store(progressUninitialized)
+
+	p.Abort()
+
+	if !p.finished.Load() {
+		t.Fatal("expected Abort to mark the bar finished")
+	}
+	// Abort must not render the bar as completed (done left as-is, not total).
+	if got := p.done.Load(); got != 400 {
+		t.Fatalf("expected done to stay 400 after Abort, got %d", got)
+	}
+	// A subsequent Finish must be a no-op and must not resurrect the bar to 100%.
+	p.Finish()
+	if got := p.done.Load(); got != 400 {
+		t.Fatalf("expected done to remain 400 after Finish following Abort, got %d", got)
+	}
+}

--- a/progressbar.go
+++ b/progressbar.go
@@ -404,6 +404,29 @@ func (p *progressBar) Finish() {
 	}
 }
 
+// Abort tears the bar down without rendering it as completed. Unlike Finish,
+// it does not set done=total or print a trailing "100%" line — use it when the
+// underlying operation failed (e.g. a server-side copy that will fall back to
+// streaming) so the user is not shown a misleading completed bar.
+func (p *progressBar) Abort() {
+	if p == nil {
+		return
+	}
+	if !p.finished.CompareAndSwap(false, true) {
+		return
+	}
+	outputMu.Lock()
+	clearActiveBars()
+	removeActiveBar(p)
+	rerenderActiveBars()
+	lastGlobalRender.Store(time.Now().UnixNano())
+	noActiveBars := len(activeBars) == 0
+	outputMu.Unlock()
+	if noActiveBars {
+		stopElapsedTicker()
+	}
+}
+
 // renderAligned writes the progress bar to stderr with the label padded to
 // labelWidth characters. This aligns bars with different-length labels.
 // outputMu must be held.


### PR DESCRIPTION
## Summary

Adds **Azure server-side copy** for `bbb sync hf://... az://...`, so HuggingFace models transfer directly into Azure Blob Storage without streaming through the client. Verified end-to-end on the real 30GB `Qwen/Qwen3-VL-30B-A3B-Instruct` sync (all 13 shards + metadata copied in ~15s).

## Changes

- **Server-side copy path**: HF->Az sync uses `CopyServerSideFromURL` (StageBlockFromURL + CommitBlockList), with a temp-file `UploadFile` streaming fallback when server-side copy isn't possible.
- **Fix 403 `CannotVerifyCopySource`**: `ResolveDirectURL` now issues a **HEAD with no Range header**. Previously it sent `Range: bytes=0-0`, which the HF Xet CDN baked into the CloudFront signed-URL policy as a `ByteRange` condition, range-locking the URL so Azure's block-range reads were rejected.
- **Diagnostics**: surface the server-side copy failure reason to stderr before falling back to streaming.
- **Fix 400 `InvalidBlobOrBlock` (self-heal)**: destination blobs poisoned by an older bbb version's uncommitted blocks (different block-ID length; Azure requires uniform ID length) rejected all new staging and stayed poisoned across runs. Both `copyBlobBlocks` and `UploadFile` now detect `InvalidBlobOrBlock`, delete the blob to clear stale uncommitted blocks, and retry the stage+commit once. Also preserved the error chain (`put failed: %w`) so `errors.As` can inspect the SDK `ResponseError`.

## Verification

- Local: self-heal tested against a still-poisoned real shard; auto-cleared and committed correctly (4.98GB, uniform 8-char block IDs), exit 0.
- Full 30GB pipeline sync succeeded; 11 shards hit the self-heal path and copied successfully, zero errors.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
