### PR TITLE
Add summary-only mode to llr

### DIFF
--- a/README.md
+++ b/README.md
@@ -368,7 +368,7 @@ bbb ll az://myaccount/mycontainer/models/
 
 ### `du` — Estimate recursive file space usage
 
-Recursively prints cumulative usage for each directory, followed by the root. Sizes use 1 KiB units by default. For object stores, usage is based on apparent blob size.
+Recursively prints human-readable cumulative usage for each directory, followed by the root. For object stores, usage is based on apparent blob size.
 
 ```bash
 bbb du -s --concurrency 32 az://myaccount/mycontainer/data/
@@ -377,8 +377,7 @@ bbb du -s --concurrency 32 az://myaccount/mycontainer/data/
 | Flag | Description |
 |------|-------------|
 | `-s`, `--summarize` | Display only a total for each argument |
-| `-h`, `--human-readable` | Print human-readable sizes |
-| `-b`, `--bytes` | Print apparent sizes in bytes |
+| `--machine` | Machine-readable tab-separated apparent bytes |
 | `--concurrency N` | Number of concurrent listing requests |
 
 ---

--- a/README.md
+++ b/README.md
@@ -348,8 +348,6 @@ bbb ls -s hf://meta-llama/Llama-2-7b/
 
 ### `ll` — Long listing (alias for `ls -l`)
 
-Aliases: `du`
-
 ```
 bbb ll [flags] [path]
 ```
@@ -365,6 +363,23 @@ bbb ll [flags] [path]
 # Show sizes and timestamps of blobs in a container
 bbb ll az://myaccount/mycontainer/models/
 ```
+
+---
+
+### `du` — Estimate recursive file space usage
+
+Recursively prints cumulative usage for each directory, followed by the root. Sizes use 1 KiB units by default. For object stores, usage is based on apparent blob size.
+
+```bash
+bbb du -s --concurrency 32 az://myaccount/mycontainer/data/
+```
+
+| Flag | Description |
+|------|-------------|
+| `-s`, `--summarize` | Display only a total for each argument |
+| `-h`, `--human-readable` | Print human-readable sizes |
+| `-b`, `--bytes` | Print apparent sizes in bytes |
+| `--concurrency N` | Number of concurrent listing requests |
 
 ---
 
@@ -407,8 +422,8 @@ bbb llr [flags] [path]
 
 | Flag | Description |
 |------|-------------|
-| `--summary` | Show only the total file count and size, with progress while counting |
-| `-s`, `--relative` | Show relative paths |
+| `-s`, `--summary` | Show only the total file count and size, with progress while counting |
+| `--relative` | Show relative paths |
 | `--machine` | Machine-readable tab-separated output |
 | `--concurrency N` | Number of concurrent listing requests |
 
@@ -418,7 +433,7 @@ bbb llr [flags] [path]
 bbb llr az://myaccount/mycontainer/
 
 # Count a large folder without printing every file
-bbb llr --summary --concurrency 32 az://myaccount/mycontainer/
+bbb llr -s --concurrency 32 az://myaccount/mycontainer/
 ```
 
 ---

--- a/README.md
+++ b/README.md
@@ -376,8 +376,8 @@ bbb du -s --concurrency 32 az://myaccount/mycontainer/data/
 
 | Flag | Description |
 |------|-------------|
-| `-s`, `--summarize` | Display only a total for each argument |
-| `--machine` | Machine-readable tab-separated apparent bytes |
+| `-s`, `--summarize` | Display only the total file count and size |
+| `--machine` | Machine-readable `count<TAB>bytes` summary with `-s` |
 | `--concurrency N` | Number of concurrent listing requests |
 
 ---

--- a/README.md
+++ b/README.md
@@ -383,6 +383,7 @@ bbb lstree [flags] [path]
 | `-l`, `--long` | Show file type, size, and modification time |
 | `-s`, `--relative` | Show relative paths |
 | `--machine` | Machine-readable tab-separated output |
+| `--concurrency N` | Number of concurrent listing requests |
 
 **Examples:**
 
@@ -406,13 +407,18 @@ bbb llr [flags] [path]
 
 | Flag | Description |
 |------|-------------|
+| `--summary` | Show only the total file count and size, with progress while counting |
 | `-s`, `--relative` | Show relative paths |
 | `--machine` | Machine-readable tab-separated output |
+| `--concurrency N` | Number of concurrent listing requests |
 
 **Example:**
 
 ```bash
 bbb llr az://myaccount/mycontainer/
+
+# Count a large folder without printing every file
+bbb llr --summary --concurrency 32 az://myaccount/mycontainer/
 ```
 
 ---

--- a/disk_usage_unix.go
+++ b/disk_usage_unix.go
@@ -1,0 +1,15 @@
+//go:build !windows
+
+package main
+
+import (
+	"os"
+	"syscall"
+)
+
+func fileAllocatedSize(info os.FileInfo) int64 {
+	if stat, ok := info.Sys().(*syscall.Stat_t); ok {
+		return stat.Blocks * 512
+	}
+	return info.Size()
+}

--- a/disk_usage_windows.go
+++ b/disk_usage_windows.go
@@ -1,0 +1,9 @@
+//go:build windows
+
+package main
+
+import "os"
+
+func fileAllocatedSize(info os.FileInfo) int64 {
+	return info.Size()
+}

--- a/internal/azblob/azblob_test.go
+++ b/internal/azblob/azblob_test.go
@@ -798,6 +798,68 @@ func TestNormalizeRootPrefixNestedPath(t *testing.T) {
 	}
 }
 
+func TestSummarizeBlobItems(t *testing.T) {
+	items := []*container.BlobItem{
+		nil,
+		{Name: nil},
+		{Name: strPtr("root/"), Properties: &container.BlobProperties{ContentLength: int64Ptr(0)}},
+		{Name: strPtr("root/a"), Properties: &container.BlobProperties{ContentLength: int64Ptr(10)}},
+		{Name: strPtr("root/b"), Properties: &container.BlobProperties{ContentLength: int64Ptr(25)}},
+		{Name: strPtr("root/no-size"), Properties: &container.BlobProperties{}},
+	}
+	count, size := summarizeBlobItems(items)
+	if count != 2 || size != 35 {
+		t.Fatalf("unexpected summary: count=%d size=%d", count, size)
+	}
+}
+
+func TestSummarizePrefixSetAggregatesMonotonicProgress(t *testing.T) {
+	type point struct {
+		count int64
+		size  int64
+	}
+	series := map[string][]point{
+		"a/": {{count: 2, size: 20}, {count: 3, size: 30}},
+		"b/": {{count: 1, size: 5}},
+		"c/": nil,
+	}
+	var progressMu sync.Mutex
+	var progress []point
+	count, size, partitionCount, err := summarizePrefixSet(
+		context.Background(),
+		[]string{"a/", "b/", "c/"},
+		2,
+		1,
+		7,
+		func(count, size int64) {
+			progressMu.Lock()
+			progress = append(progress, point{count: count, size: size})
+			progressMu.Unlock()
+		},
+		func(_ context.Context, prefix string, onProgress func(count, size int64)) (int64, int64, error) {
+			for _, p := range series[prefix] {
+				onProgress(p.count, p.size)
+			}
+			if len(series[prefix]) == 0 {
+				return 0, 0, nil
+			}
+			last := series[prefix][len(series[prefix])-1]
+			return last.count, last.size, nil
+		},
+	)
+	if err != nil {
+		t.Fatalf("summarizePrefixSet: %v", err)
+	}
+	if count != 5 || size != 42 || partitionCount != 4 {
+		t.Fatalf("unexpected totals: count=%d size=%d partitionCount=%d", count, size, partitionCount)
+	}
+	for i := 1; i < len(progress); i++ {
+		if progress[i].count < progress[i-1].count || progress[i].size < progress[i-1].size {
+			t.Fatalf("non-monotonic progress at %d: %+v", i, progress)
+		}
+	}
+}
+
 // --- ListRecursiveStream context cancellation test ---
 
 func TestListRecursiveStreamCancelledContext(t *testing.T) {

--- a/internal/azblob/summary.go
+++ b/internal/azblob/summary.go
@@ -1,0 +1,230 @@
+package azblob
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"strings"
+	"sync"
+
+	"github.com/Azure/azure-sdk-for-go/sdk/azcore"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob"
+	"github.com/Azure/azure-sdk-for-go/sdk/storage/azblob/container"
+)
+
+// SummarizeRecursive counts blobs and bytes under ap. When the root contains
+// multiple virtual directories, each directory is scanned independently so
+// Azure continuation-token chains can advance in parallel.
+func SummarizeRecursive(ctx context.Context, ap AzurePath, scanConcurrency int, onProgress func(count, size int64)) (int64, int64, error) {
+	rootPrefix := normalizeRootPrefix(ap.Blob)
+	client, err := getAzBlobClient(ctx, ap.Account)
+	if err != nil {
+		return 0, 0, err
+	}
+	containerClient := client.ServiceClient().NewContainerClient(ap.Container)
+	if scanConcurrency <= 1 {
+		return summarizeFlat(ctx, containerClient, ap.Container, rootPrefix, onProgress)
+	}
+
+	prefixes, rootCount, rootSize, err := summaryPartitions(ctx, containerClient, ap.Container, rootPrefix)
+	if err != nil {
+		return 0, 0, err
+	}
+	if len(prefixes) < 2 {
+		return summarizeFlat(ctx, containerClient, ap.Container, rootPrefix, onProgress)
+	}
+
+	count, size, partitionCount, err := summarizePrefixSet(
+		ctx, prefixes, scanConcurrency, rootCount, rootSize, onProgress,
+		func(ctx context.Context, prefix string, progress func(count, size int64)) (int64, int64, error) {
+			return summarizeFlat(ctx, containerClient, ap.Container, prefix, progress)
+		},
+	)
+	if err != nil {
+		return count, size, err
+	}
+	if partitionCount == 0 {
+		// Azurite versions that support hierarchy listing can still return no
+		// results for flat listings scoped to a virtual-directory prefix.
+		return summarizeFlat(ctx, containerClient, ap.Container, rootPrefix, func(flatCount, flatSize int64) {
+			if onProgress != nil && flatCount >= count && flatSize >= size {
+				onProgress(flatCount, flatSize)
+			}
+		})
+	}
+	return count, size, nil
+}
+
+func summaryPartitions(ctx context.Context, client *container.Client, containerName, rootPrefix string) ([]string, int64, int64, error) {
+	opts := &container.ListBlobsHierarchyOptions{}
+	if rootPrefix != "" {
+		opts.Prefix = &rootPrefix
+	}
+	pager := client.NewListBlobsHierarchyPager("/", opts)
+	seen := make(map[string]struct{})
+	var prefixes []string
+	var count, size int64
+	for pager.More() {
+		resp, err := pager.NextPage(ctx)
+		if err != nil {
+			return nil, 0, 0, summaryListError(err, containerName)
+		}
+		if resp.Segment == nil {
+			break
+		}
+		for _, prefix := range resp.Segment.BlobPrefixes {
+			if prefix == nil || prefix.Name == nil {
+				continue
+			}
+			if _, ok := seen[*prefix.Name]; ok {
+				continue
+			}
+			seen[*prefix.Name] = struct{}{}
+			prefixes = append(prefixes, *prefix.Name)
+		}
+		pageCount, pageSize := summarizeBlobItems(resp.Segment.BlobItems)
+		count += pageCount
+		size += pageSize
+	}
+	return prefixes, count, size, nil
+}
+
+type prefixSummarizer func(ctx context.Context, prefix string, onProgress func(count, size int64)) (int64, int64, error)
+
+func summarizePrefixSet(
+	ctx context.Context,
+	prefixes []string,
+	concurrency int,
+	initialCount, initialSize int64,
+	onProgress func(count, size int64),
+	summarize prefixSummarizer,
+) (int64, int64, int64, error) {
+	if concurrency > len(prefixes) {
+		concurrency = len(prefixes)
+	}
+	if concurrency < 1 {
+		concurrency = 1
+	}
+
+	workerCtx, cancel := context.WithCancel(ctx)
+	defer cancel()
+	jobs := make(chan string)
+	var aggregateMu sync.Mutex
+	count := initialCount
+	size := initialSize
+	var partitionCount int64
+	if onProgress != nil && initialCount > 0 {
+		onProgress(initialCount, initialSize)
+	}
+	addProgress := func(countDelta, sizeDelta int64) {
+		aggregateMu.Lock()
+		defer aggregateMu.Unlock()
+		partitionCount += countDelta
+		count += countDelta
+		size += sizeDelta
+		if onProgress != nil {
+			onProgress(count, size)
+		}
+	}
+	snapshot := func() (int64, int64, int64) {
+		aggregateMu.Lock()
+		defer aggregateMu.Unlock()
+		return count, size, partitionCount
+	}
+
+	var firstErr error
+	var errOnce sync.Once
+	setErr := func(err error) {
+		errOnce.Do(func() {
+			firstErr = err
+			cancel()
+		})
+	}
+
+	var workers sync.WaitGroup
+	workers.Add(concurrency)
+	for range concurrency {
+		go func() {
+			defer workers.Done()
+			for prefix := range jobs {
+				var previousCount, previousSize int64
+				_, _, err := summarize(workerCtx, prefix, func(prefixCount, prefixSize int64) {
+					countDelta := prefixCount - previousCount
+					sizeDelta := prefixSize - previousSize
+					previousCount = prefixCount
+					previousSize = prefixSize
+					addProgress(countDelta, sizeDelta)
+				})
+				if err != nil {
+					setErr(err)
+					return
+				}
+			}
+		}()
+	}
+
+sendLoop:
+	for _, prefix := range prefixes {
+		select {
+		case jobs <- prefix:
+		case <-workerCtx.Done():
+			break sendLoop
+		}
+	}
+	close(jobs)
+	workers.Wait()
+	finalCount, finalSize, finalPartitionCount := snapshot()
+	if firstErr != nil {
+		return finalCount, finalSize, finalPartitionCount, firstErr
+	}
+	if err := ctx.Err(); err != nil {
+		return finalCount, finalSize, finalPartitionCount, err
+	}
+	return finalCount, finalSize, finalPartitionCount, nil
+}
+
+func summarizeFlat(ctx context.Context, client *container.Client, containerName, prefix string, onProgress func(count, size int64)) (int64, int64, error) {
+	opts := &azblob.ListBlobsFlatOptions{}
+	if prefix != "" {
+		opts.Prefix = &prefix
+	}
+	pager := client.NewListBlobsFlatPager(opts)
+	var count, size int64
+	for pager.More() {
+		resp, err := pager.NextPage(ctx)
+		if err != nil {
+			return count, size, summaryListError(err, containerName)
+		}
+		if resp.Segment == nil {
+			break
+		}
+		pageCount, pageSize := summarizeBlobItems(resp.Segment.BlobItems)
+		count += pageCount
+		size += pageSize
+		if onProgress != nil && pageCount > 0 {
+			onProgress(count, size)
+		}
+	}
+	return count, size, nil
+}
+
+func summarizeBlobItems(items []*container.BlobItem) (int64, int64) {
+	var count, size int64
+	for _, blob := range items {
+		if blob == nil || blob.Name == nil || strings.HasSuffix(*blob.Name, "/") ||
+			blob.Properties == nil || blob.Properties.ContentLength == nil {
+			continue
+		}
+		count++
+		size += *blob.Properties.ContentLength
+	}
+	return count, size
+}
+
+func summaryListError(err error, containerName string) error {
+	var responseErr *azcore.ResponseError
+	if errors.As(err, &responseErr) && responseErr.ErrorCode == "ContainerNotFound" {
+		return fmt.Errorf("container '%s' not found", containerName)
+	}
+	return err
+}

--- a/internal/bbbfs/az.go
+++ b/internal/bbbfs/az.go
@@ -163,6 +163,15 @@ func (azFS) ListRecursive(ctx context.Context, target string, emit func(Entry) e
 	})
 }
 
+func (azFS) SummarizeRecursive(ctx context.Context, target string, onProgress func(count, size int64)) (RecursiveSummary, error) {
+	ap, err := azblob.Parse(target)
+	if err != nil {
+		return RecursiveSummary{}, err
+	}
+	count, size, err := azblob.SummarizeRecursive(ctx, ap, ScanConcurrency(ctx), onProgress)
+	return RecursiveSummary{FileCount: count, TotalSize: size}, err
+}
+
 func azChildPath(ap azblob.AzurePath, name string) string {
 	trimmed := strings.TrimSuffix(name, "/")
 	return ap.Child(trimmed).String()

--- a/internal/bbbfs/bbbfs_test.go
+++ b/internal/bbbfs/bbbfs_test.go
@@ -70,6 +70,26 @@ func TestListRecursiveLocalNestedPaths(t *testing.T) {
 	}
 }
 
+func TestSummarizeRecursiveLocal(t *testing.T) {
+	root := t.TempDir()
+	if err := os.MkdirAll(filepath.Join(root, "sub"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a"), []byte("abc"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "sub", "b"), []byte("12345"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	summary, err := SummarizeRecursive(context.Background(), root, nil)
+	if err != nil {
+		t.Fatalf("SummarizeRecursive: %v", err)
+	}
+	if summary.FileCount != 2 || summary.TotalSize != 8 {
+		t.Fatalf("unexpected summary: %+v", summary)
+	}
+}
+
 func TestProvidersImplementRecursiveLister(t *testing.T) {
 	if _, ok := any(azFS{}).(recursiveLister); !ok {
 		t.Fatalf("azFS should implement recursiveLister")

--- a/internal/bbbfs/list_recursive.go
+++ b/internal/bbbfs/list_recursive.go
@@ -12,6 +12,42 @@ type recursiveLister interface {
 	ListRecursive(ctx context.Context, root string, emit func(Entry) error) error
 }
 
+type recursiveSummarizer interface {
+	SummarizeRecursive(ctx context.Context, root string, onProgress func(count, size int64)) (RecursiveSummary, error)
+}
+
+// RecursiveSummary contains aggregate metadata for a recursive file listing.
+type RecursiveSummary struct {
+	FileCount int64
+	TotalSize int64
+}
+
+// SummarizeRecursive returns aggregate file count and size without retaining
+// individual entries. Backends may optimize this operation independently.
+func SummarizeRecursive(ctx context.Context, root string, onProgress func(count, size int64)) (RecursiveSummary, error) {
+	if summarizer, ok := Resolve(root).(recursiveSummarizer); ok {
+		return summarizer.SummarizeRecursive(ctx, root, onProgress)
+	}
+	var summary RecursiveSummary
+	for result := range ListRecursive(ctx, root) {
+		if result.Err != nil {
+			return summary, result.Err
+		}
+		if result.Entry.Name == "" || result.Entry.IsDir {
+			continue
+		}
+		summary.FileCount++
+		summary.TotalSize += result.Entry.Size
+		if onProgress != nil && summary.FileCount%4096 == 0 {
+			onProgress(summary.FileCount, summary.TotalSize)
+		}
+	}
+	if onProgress != nil {
+		onProgress(summary.FileCount, summary.TotalSize)
+	}
+	return summary, nil
+}
+
 // ListRecursive returns a channel that streams all files under the path.
 // Entries are emitted as they are discovered; any listing error is sent as a
 // ListResult with Err set. The channel is closed when listing completes or

--- a/main.go
+++ b/main.go
@@ -704,6 +704,35 @@ func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
 	}
 
 	parentPath, pattern := splitWildcard(root)
+	if summary && pattern == "" {
+		countingBar := newCountingProgressBar("Counting", machine)
+		completed := false
+		defer func() {
+			if countingBar == nil {
+				return
+			}
+			if completed {
+				countingBar.Finish()
+			} else {
+				countingBar.Abort()
+			}
+		}()
+		result, err := bbbfs.SummarizeRecursive(ctx, parentPath, func(count, size int64) {
+			countingBar.SetCountAndBytes(count, size)
+		})
+		if err != nil {
+			return err
+		}
+		completed = true
+		countingBar.Finish()
+		countingBar = nil
+		if machine {
+			fmt.Printf("%d\t%d\n", result.FileCount, result.TotalSize)
+		} else {
+			printListSummary(result.FileCount, result.TotalSize)
+		}
+		return nil
+	}
 	var count int64
 	var totalSize int64
 	countingBar := newCountingProgressBar("Counting", !summary)
@@ -779,13 +808,17 @@ func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
 	if summary && machine {
 		fmt.Printf("%d\t%d\n", count, totalSize)
 	} else if !machine {
-		noun := "files"
-		if count == 1 {
-			noun = "file"
-		}
-		fmt.Printf("Listed %d %s summing to %s (%d bytes)\n", count, noun, formatSize(totalSize), totalSize)
+		printListSummary(count, totalSize)
 	}
 	return nil
+}
+
+func printListSummary(count, totalSize int64) {
+	noun := "files"
+	if count == 1 {
+		noun = "file"
+	}
+	fmt.Printf("Listed %d %s summing to %s (%d bytes)\n", count, noun, formatSize(totalSize), totalSize)
 }
 
 func splitWildcard(target string) (string, string) {

--- a/main.go
+++ b/main.go
@@ -260,6 +260,8 @@ func newCachingDialContext(baseDial dialContextFunc, lookup lookupHostFunc, ttl 
 }
 
 func main() {
+	// Reserve -h for command-specific human-readable flags such as du -h.
+	cli.HelpFlag = &cli.BoolFlag{Name: "help", Usage: "Show help", HideDefault: true, Local: true}
 	// logLevel will be set from global flag after parsing
 	app := &cli.Command{
 		Name:    "bbb",
@@ -477,7 +479,6 @@ func main() {
 			},
 			{
 				Name:      "ll",
-				Aliases:   []string{"du"},
 				Usage:     "Alias for 'ls -l' (long listing)",
 				UsageText: "bbb ll [-s|--relative] [--machine] [path]",
 				Flags: []cli.Flag{
@@ -485,6 +486,18 @@ func main() {
 					&cli.BoolFlag{Name: "machine", Usage: "Machine-readable (tab-separated) output"},
 				},
 				Action: cmdLL,
+			},
+			{
+				Name:      "du",
+				Usage:     "Estimate recursive file space usage",
+				UsageText: "bbb du [-s|--summarize] [-h|--human-readable] [-b|--bytes] [--concurrency N] [path ...]",
+				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "summarize", Aliases: []string{"s"}, Usage: "Display only a total for each argument"},
+					&cli.BoolFlag{Name: "human-readable", Aliases: []string{"h"}, Usage: "Print sizes in human-readable form"},
+					&cli.BoolFlag{Name: "bytes", Aliases: []string{"b"}, Usage: "Print apparent sizes in bytes"},
+					&cli.IntFlag{Name: "concurrency", Usage: "Number of concurrent listing requests", Value: runtime.NumCPU()},
+				},
+				Action: cmdDU,
 			},
 			{
 				Name:      "lstree",
@@ -502,10 +515,10 @@ func main() {
 			{
 				Name:      "llr",
 				Usage:     "Alias for 'lstree -l' (recursive long file list)",
-				UsageText: "bbb llr [--summary] [-s|--relative] [--machine] [--concurrency N] [path]",
+				UsageText: "bbb llr [-s|--summary] [--relative] [--machine] [--concurrency N] [path]",
 				Flags: []cli.Flag{
-					&cli.BoolFlag{Name: "summary", Usage: "Show only the total file count and size"},
-					&cli.BoolFlag{Name: "s", Aliases: []string{"relative"}, Usage: "Show relative paths"},
+					&cli.BoolFlag{Name: "summary", Aliases: []string{"s"}, Usage: "Show only the total file count and size"},
+					&cli.BoolFlag{Name: "relative", Usage: "Show relative paths"},
 					&cli.BoolFlag{Name: "machine", Usage: "Machine-readable (tab-separated) output"},
 					&cli.IntFlag{Name: "concurrency", Usage: "Number of concurrent listing requests", Value: runtime.NumCPU()},
 				},
@@ -614,7 +627,7 @@ func cmdLS(ctx context.Context, c *cli.Command) error {
 		target = c.Args().Get(0)
 	}
 	machine := c.Bool("machine")
-	relFlag := c.Bool("s")
+	relFlag := c.Bool("s") || c.Bool("relative")
 	parentPath, pattern := splitWildcard(target)
 	fs := bbbfs.Resolve(parentPath)
 	entries, err := fs.List(ctx, parentPath)
@@ -687,6 +700,203 @@ func cmdLS(ctx context.Context, c *cli.Command) error {
 
 func cmdLSTree(ctx context.Context, c *cli.Command) error { return runListTree(ctx, c, false) }
 
+type diskUsage struct {
+	relative  string
+	allocated int64
+	apparent  int64
+}
+
+func cmdDU(ctx context.Context, c *cli.Command) error {
+	if c.Bool("human-readable") && c.Bool("bytes") {
+		return errors.New("du: --human-readable and --bytes are mutually exclusive")
+	}
+	if conc := c.Int("concurrency"); conc > 0 {
+		ctx = bbbfs.WithScanConcurrency(ctx, conc)
+	}
+	roots := c.Args().Slice()
+	if len(roots) == 0 {
+		roots = []string{"."}
+	}
+	for _, root := range roots {
+		if c.Bool("summarize") {
+			if !strings.Contains(root, "://") {
+				usages, err := collectDiskUsage(ctx, root)
+				if err != nil {
+					return err
+				}
+				usage := usages[len(usages)-1]
+				printDiskUsage(usage, root, c.Bool("human-readable"), c.Bool("bytes"))
+			} else {
+				bar := newCountingProgressBar("Counting", false)
+				result, err := bbbfs.SummarizeRecursive(ctx, root, func(count, size int64) {
+					bar.SetCountAndBytes(count, size)
+				})
+				if err != nil {
+					bar.Abort()
+					return err
+				}
+				bar.Finish()
+				printDiskUsage(diskUsage{allocated: result.TotalSize, apparent: result.TotalSize}, root, c.Bool("human-readable"), c.Bool("bytes"))
+			}
+			continue
+		}
+		usages, err := collectDiskUsage(ctx, root)
+		if err != nil {
+			return err
+		}
+		for _, usage := range usages {
+			printDiskUsage(usage, diskUsagePath(root, usage.relative), c.Bool("human-readable"), c.Bool("bytes"))
+		}
+	}
+	return nil
+}
+
+func collectDiskUsage(ctx context.Context, root string) ([]diskUsage, error) {
+	sizes := map[string]diskUsage{"": {}}
+	if strings.Contains(root, "://") {
+		for result := range bbbfs.ListRecursive(ctx, root) {
+			if result.Err != nil {
+				return nil, result.Err
+			}
+			entry := result.Entry
+			if entry.Name == "" || entry.IsDir {
+				continue
+			}
+			addDiskUsage(sizes, path.Dir(filepath.ToSlash(entry.Name)), entry.Size, entry.Size)
+		}
+	} else {
+		err := filepath.WalkDir(root, func(current string, entry os.DirEntry, walkErr error) error {
+			if walkErr != nil {
+				return walkErr
+			}
+			if err := ctx.Err(); err != nil {
+				return err
+			}
+			relative, err := filepath.Rel(root, current)
+			if err != nil {
+				return err
+			}
+			relative = filepath.ToSlash(relative)
+			if relative == "." {
+				relative = ""
+			}
+			if entry.IsDir() {
+				if _, ok := sizes[relative]; !ok {
+					sizes[relative] = diskUsage{}
+				}
+			}
+			info, err := entry.Info()
+			if err != nil {
+				return err
+			}
+			dir := path.Dir(relative)
+			apparent := info.Size()
+			if entry.IsDir() {
+				dir = relative
+				apparent = 0
+			}
+			addDiskUsage(sizes, dir, fileAllocatedSize(info), apparent)
+			return nil
+		})
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	children := make(map[string][]string)
+	for dir := range sizes {
+		if dir == "" {
+			continue
+		}
+		parent := path.Dir(dir)
+		if parent == "." {
+			parent = ""
+		}
+		children[parent] = append(children[parent], dir)
+	}
+	for parent := range children {
+		sort.Strings(children[parent])
+	}
+	usages := make([]diskUsage, 0, len(sizes))
+	var appendPostOrder func(string)
+	appendPostOrder = func(dir string) {
+		for _, child := range children[dir] {
+			appendPostOrder(child)
+		}
+		usage := sizes[dir]
+		usage.relative = dir
+		usages = append(usages, usage)
+	}
+	appendPostOrder("")
+	return usages, nil
+}
+
+func addDiskUsage(sizes map[string]diskUsage, dir string, allocated, apparent int64) {
+	if dir == "." {
+		dir = ""
+	}
+	for {
+		usage := sizes[dir]
+		usage.allocated += allocated
+		usage.apparent += apparent
+		sizes[dir] = usage
+		if dir == "" {
+			return
+		}
+		parent := path.Dir(dir)
+		if parent == "." {
+			parent = ""
+		}
+		dir = parent
+	}
+}
+
+func diskUsagePath(root, relative string) string {
+	if relative == "" {
+		return root
+	}
+	if strings.Contains(root, "://") {
+		return strings.TrimSuffix(root, "/") + "/" + relative
+	}
+	if root == "." {
+		return "." + string(filepath.Separator) + filepath.FromSlash(relative)
+	}
+	return filepath.Join(root, filepath.FromSlash(relative))
+}
+
+func printDiskUsage(usage diskUsage, name string, humanReadable, bytes bool) {
+	switch {
+	case humanReadable:
+		fmt.Printf("%s\t%s\n", formatDiskUsageSize(usage.allocated), name)
+	case bytes:
+		fmt.Printf("%d\t%s\n", usage.apparent, name)
+	default:
+		blocks := (usage.allocated + 1023) / 1024
+		fmt.Printf("%d\t%s\n", blocks, name)
+	}
+}
+
+func formatDiskUsageSize(bytes int64) string {
+	if bytes <= 0 {
+		return "0"
+	}
+	const unit = 1024.0
+	suffixes := [...]string{"K", "M", "G", "T", "P", "E"}
+	value := float64(bytes)
+	suffix := ""
+	for _, candidate := range suffixes {
+		value /= unit
+		suffix = candidate
+		if value < unit {
+			break
+		}
+	}
+	if value < 10 {
+		return fmt.Sprintf("%.1f%s", value, suffix)
+	}
+	return fmt.Sprintf("%.0f%s", value, suffix)
+}
+
 // runListTree implements recursive file-only listing for lstree and llr.
 // longForced is true for llr alias to imply -l.
 func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
@@ -697,8 +907,8 @@ func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
 	}
 	longFlag := c.Bool("l") || c.Bool("long") || longForced
 	machine := c.Bool("machine")
-	relFlag := c.Bool("s") || c.Bool("relative")
 	summary := c.Bool("summary")
+	relFlag := c.Bool("relative") || (c.Bool("s") && !summary)
 	if conc := c.Int("concurrency"); conc > 0 {
 		ctx = bbbfs.WithScanConcurrency(ctx, conc)
 	}

--- a/main.go
+++ b/main.go
@@ -502,8 +502,9 @@ func main() {
 			{
 				Name:      "llr",
 				Usage:     "Alias for 'lstree -l' (recursive long file list)",
-				UsageText: "bbb llr [-s|--relative] [--machine] [--concurrency N] [path]",
+				UsageText: "bbb llr [--summary] [-s|--relative] [--machine] [--concurrency N] [path]",
 				Flags: []cli.Flag{
+					&cli.BoolFlag{Name: "summary", Usage: "Show only the total file count and size"},
 					&cli.BoolFlag{Name: "s", Aliases: []string{"relative"}, Usage: "Show relative paths"},
 					&cli.BoolFlag{Name: "machine", Usage: "Machine-readable (tab-separated) output"},
 					&cli.IntFlag{Name: "concurrency", Usage: "Number of concurrent listing requests", Value: runtime.NumCPU()},
@@ -697,6 +698,7 @@ func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
 	longFlag := c.Bool("l") || c.Bool("long") || longForced
 	machine := c.Bool("machine")
 	relFlag := c.Bool("s") || c.Bool("relative")
+	summary := c.Bool("summary")
 	if conc := c.Int("concurrency"); conc > 0 {
 		ctx = bbbfs.WithScanConcurrency(ctx, conc)
 	}
@@ -704,6 +706,18 @@ func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
 	parentPath, pattern := splitWildcard(root)
 	var count int64
 	var totalSize int64
+	countingBar := newCountingProgressBar("Counting", !summary)
+	completed := false
+	defer func() {
+		if countingBar == nil {
+			return
+		}
+		if completed {
+			countingBar.Finish()
+		} else {
+			countingBar.Abort()
+		}
+	}()
 	for result := range bbbfs.ListRecursive(ctx, parentPath) {
 		if result.Err != nil {
 			return result.Err
@@ -728,6 +742,13 @@ func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
 		}
 		count++
 		totalSize += entry.Size
+		if countingBar != nil {
+			countingBar.AddBytes(entry.Size)
+			countingBar.Increment()
+		}
+		if summary {
+			continue
+		}
 		display := entry.Path
 		if relFlag {
 			display = name
@@ -750,7 +771,14 @@ func runListTree(ctx context.Context, c *cli.Command, longForced bool) error {
 			}
 		}
 	}
-	if !machine {
+	completed = true
+	if countingBar != nil {
+		countingBar.Finish()
+		countingBar = nil
+	}
+	if summary && machine {
+		fmt.Printf("%d\t%d\n", count, totalSize)
+	} else if !machine {
 		noun := "files"
 		if count == 1 {
 			noun = "file"

--- a/main.go
+++ b/main.go
@@ -260,8 +260,6 @@ func newCachingDialContext(baseDial dialContextFunc, lookup lookupHostFunc, ttl 
 }
 
 func main() {
-	// Reserve -h for command-specific human-readable flags such as du -h.
-	cli.HelpFlag = &cli.BoolFlag{Name: "help", Usage: "Show help", HideDefault: true, Local: true}
 	// logLevel will be set from global flag after parsing
 	app := &cli.Command{
 		Name:    "bbb",
@@ -490,11 +488,10 @@ func main() {
 			{
 				Name:      "du",
 				Usage:     "Estimate recursive file space usage",
-				UsageText: "bbb du [-s|--summarize] [-h|--human-readable] [-b|--bytes] [--concurrency N] [path ...]",
+				UsageText: "bbb du [-s|--summarize] [--machine] [--concurrency N] [path ...]",
 				Flags: []cli.Flag{
 					&cli.BoolFlag{Name: "summarize", Aliases: []string{"s"}, Usage: "Display only a total for each argument"},
-					&cli.BoolFlag{Name: "human-readable", Aliases: []string{"h"}, Usage: "Print sizes in human-readable form"},
-					&cli.BoolFlag{Name: "bytes", Aliases: []string{"b"}, Usage: "Print apparent sizes in bytes"},
+					&cli.BoolFlag{Name: "machine", Usage: "Machine-readable (tab-separated) output"},
 					&cli.IntFlag{Name: "concurrency", Usage: "Number of concurrent listing requests", Value: runtime.NumCPU()},
 				},
 				Action: cmdDU,
@@ -707,9 +704,6 @@ type diskUsage struct {
 }
 
 func cmdDU(ctx context.Context, c *cli.Command) error {
-	if c.Bool("human-readable") && c.Bool("bytes") {
-		return errors.New("du: --human-readable and --bytes are mutually exclusive")
-	}
 	if conc := c.Int("concurrency"); conc > 0 {
 		ctx = bbbfs.WithScanConcurrency(ctx, conc)
 	}
@@ -725,7 +719,7 @@ func cmdDU(ctx context.Context, c *cli.Command) error {
 					return err
 				}
 				usage := usages[len(usages)-1]
-				printDiskUsage(usage, root, c.Bool("human-readable"), c.Bool("bytes"))
+				printDiskUsage(usage, root, c.Bool("machine"))
 			} else {
 				bar := newCountingProgressBar("Counting", false)
 				result, err := bbbfs.SummarizeRecursive(ctx, root, func(count, size int64) {
@@ -736,7 +730,7 @@ func cmdDU(ctx context.Context, c *cli.Command) error {
 					return err
 				}
 				bar.Finish()
-				printDiskUsage(diskUsage{allocated: result.TotalSize, apparent: result.TotalSize}, root, c.Bool("human-readable"), c.Bool("bytes"))
+				printDiskUsage(diskUsage{allocated: result.TotalSize, apparent: result.TotalSize}, root, c.Bool("machine"))
 			}
 			continue
 		}
@@ -745,7 +739,7 @@ func cmdDU(ctx context.Context, c *cli.Command) error {
 			return err
 		}
 		for _, usage := range usages {
-			printDiskUsage(usage, diskUsagePath(root, usage.relative), c.Bool("human-readable"), c.Bool("bytes"))
+			printDiskUsage(usage, diskUsagePath(root, usage.relative), c.Bool("machine"))
 		}
 	}
 	return nil
@@ -864,21 +858,20 @@ func diskUsagePath(root, relative string) string {
 	return filepath.Join(root, filepath.FromSlash(relative))
 }
 
-func printDiskUsage(usage diskUsage, name string, humanReadable, bytes bool) {
-	switch {
-	case humanReadable:
-		fmt.Printf("%s\t%s\n", formatDiskUsageSize(usage.allocated), name)
-	case bytes:
+func printDiskUsage(usage diskUsage, name string, machine bool) {
+	if machine {
 		fmt.Printf("%d\t%s\n", usage.apparent, name)
-	default:
-		blocks := (usage.allocated + 1023) / 1024
-		fmt.Printf("%d\t%s\n", blocks, name)
+		return
 	}
+	fmt.Printf("%s\t%s\n", formatDiskUsageSize(usage.allocated), name)
 }
 
 func formatDiskUsageSize(bytes int64) string {
 	if bytes <= 0 {
 		return "0"
+	}
+	if bytes < 1024 {
+		return fmt.Sprintf("%dB", bytes)
 	}
 	const unit = 1024.0
 	suffixes := [...]string{"K", "M", "G", "T", "P", "E"}

--- a/main.go
+++ b/main.go
@@ -713,24 +713,19 @@ func cmdDU(ctx context.Context, c *cli.Command) error {
 	}
 	for _, root := range roots {
 		if c.Bool("summarize") {
-			if !strings.Contains(root, "://") {
-				usages, err := collectDiskUsage(ctx, root)
-				if err != nil {
-					return err
-				}
-				usage := usages[len(usages)-1]
-				printDiskUsage(usage, root, c.Bool("machine"))
+			bar := newCountingProgressBar("Counting", c.Bool("machine"))
+			result, err := bbbfs.SummarizeRecursive(ctx, root, func(count, size int64) {
+				bar.SetCountAndBytes(count, size)
+			})
+			if err != nil {
+				bar.Abort()
+				return err
+			}
+			bar.Finish()
+			if c.Bool("machine") {
+				fmt.Printf("%d\t%d\n", result.FileCount, result.TotalSize)
 			} else {
-				bar := newCountingProgressBar("Counting", false)
-				result, err := bbbfs.SummarizeRecursive(ctx, root, func(count, size int64) {
-					bar.SetCountAndBytes(count, size)
-				})
-				if err != nil {
-					bar.Abort()
-					return err
-				}
-				bar.Finish()
-				printDiskUsage(diskUsage{allocated: result.TotalSize, apparent: result.TotalSize}, root, c.Bool("machine"))
+				printListSummary(result.FileCount, result.TotalSize)
 			}
 			continue
 		}

--- a/main_test.go
+++ b/main_test.go
@@ -1059,11 +1059,87 @@ func TestFormatProgressBarIncludesSpeed(t *testing.T) {
 	}
 }
 
+func TestFormatCountingBar(t *testing.T) {
+	line := formatCountingBar("Counting", 3, 1536, 5, 200*time.Millisecond, false)
+	if line != "Counting [  >  ] 3 files (1.5 KiB) 0s" {
+		t.Fatalf("unexpected counting bar output: %s", line)
+	}
+
+	line = formatCountingBar("Counting", 1, 512, 5, 2*time.Second, true)
+	if line != "Counting [=====] 1 file (512 B) 2s" {
+		t.Fatalf("unexpected completed counting bar output: %s", line)
+	}
+}
+
 func TestFormatProgressBarClampsDoneToTotal(t *testing.T) {
 	line := formatProgressBar("cp", 7, 5, 10, 1*1024*1024, true, false, 5*time.Second)
 	if line != "cp [==========] 100% (5/5, 1.0 MB/s) 5s" {
 		t.Fatalf("unexpected clamped output: %s", line)
 	}
+}
+
+func TestLLRSummaryOnly(t *testing.T) {
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a.txt"), []byte("abc"), 0o644); err != nil {
+		t.Fatalf("write a.txt: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "nested", "b.txt"), []byte("12345"), 0o644); err != nil {
+		t.Fatalf("write b.txt: %v", err)
+	}
+
+	app := &cli.Command{
+		Action: func(ctx context.Context, c *cli.Command) error {
+			return runListTree(ctx, c, true)
+		},
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "summary"},
+			&cli.BoolFlag{Name: "machine"},
+			&cli.BoolFlag{Name: "s", Aliases: []string{"relative"}},
+			&cli.IntFlag{Name: "concurrency", Value: 1},
+		},
+	}
+
+	output := captureStdout(t, func() error {
+		return app.Run(context.Background(), []string{"llr", "--summary", "--concurrency", "4", root})
+	})
+	if output != "Listed 2 files summing to 8 B (8 bytes)\n" {
+		t.Fatalf("unexpected summary output: %q", output)
+	}
+
+	output = captureStdout(t, func() error {
+		return app.Run(context.Background(), []string{"llr", "--summary", "--machine", root})
+	})
+	if output != "2\t8\n" {
+		t.Fatalf("unexpected machine summary output: %q", output)
+	}
+}
+
+func captureStdout(t *testing.T, run func() error) string {
+	t.Helper()
+	original := os.Stdout
+	r, w, err := os.Pipe()
+	if err != nil {
+		t.Fatalf("pipe stdout: %v", err)
+	}
+	os.Stdout = w
+	runErr := run()
+	closeErr := w.Close()
+	os.Stdout = original
+	output, readErr := io.ReadAll(r)
+	_ = r.Close()
+	if runErr != nil {
+		t.Fatalf("command failed: %v", runErr)
+	}
+	if closeErr != nil {
+		t.Fatalf("close stdout: %v", closeErr)
+	}
+	if readErr != nil {
+		t.Fatalf("read stdout: %v", readErr)
+	}
+	return string(output)
 }
 
 func TestFormatProgressBarNormalizesWidth(t *testing.T) {

--- a/main_test.go
+++ b/main_test.go
@@ -1139,14 +1139,14 @@ func TestDUSummaryIsRecursive(t *testing.T) {
 	output := captureStdout(t, func() error {
 		return app.Run(context.Background(), []string{"du", "-s", root})
 	})
-	if !strings.HasSuffix(output, "\t"+root+"\n") {
+	if output != "Listed 2 files summing to 8 B (8 bytes)\n" {
 		t.Fatalf("unexpected du summary output: %q", output)
 	}
 
 	output = captureStdout(t, func() error {
 		return app.Run(context.Background(), []string{"du", "--machine", "-s", root})
 	})
-	if output != "8\t"+root+"\n" {
+	if output != "2\t8\n" {
 		t.Fatalf("unexpected machine du summary output: %q", output)
 	}
 }
@@ -1182,7 +1182,7 @@ func TestDUDefaultPrintsDirectoriesPostOrder(t *testing.T) {
 	output = captureStdout(t, func() error {
 		return app.Run(context.Background(), []string{"du", "--machine", "-s", root})
 	})
-	if output != "8\t"+root+"\n" {
+	if output != "2\t8\n" {
 		t.Fatalf("unexpected machine du output: %q", output)
 	}
 }

--- a/main_test.go
+++ b/main_test.go
@@ -1095,15 +1095,15 @@ func TestLLRSummaryOnly(t *testing.T) {
 			return runListTree(ctx, c, true)
 		},
 		Flags: []cli.Flag{
-			&cli.BoolFlag{Name: "summary"},
+			&cli.BoolFlag{Name: "summary", Aliases: []string{"s"}},
 			&cli.BoolFlag{Name: "machine"},
-			&cli.BoolFlag{Name: "s", Aliases: []string{"relative"}},
+			&cli.BoolFlag{Name: "relative"},
 			&cli.IntFlag{Name: "concurrency", Value: 1},
 		},
 	}
 
 	output := captureStdout(t, func() error {
-		return app.Run(context.Background(), []string{"llr", "--summary", "--concurrency", "4", root})
+		return app.Run(context.Background(), []string{"llr", "-s", "--concurrency", "4", root})
 	})
 	if output != "Listed 2 files summing to 8 B (8 bytes)\n" {
 		t.Fatalf("unexpected summary output: %q", output)
@@ -1114,6 +1114,106 @@ func TestLLRSummaryOnly(t *testing.T) {
 	})
 	if output != "2\t8\n" {
 		t.Fatalf("unexpected machine summary output: %q", output)
+	}
+}
+
+func TestDUSummaryIsRecursive(t *testing.T) {
+	originalHelpFlag := cli.HelpFlag
+	cli.HelpFlag = &cli.BoolFlag{Name: "help", Usage: "Show help", HideDefault: true, Local: true}
+	defer func() { cli.HelpFlag = originalHelpFlag }()
+
+	root := t.TempDir()
+	if err := os.Mkdir(filepath.Join(root, "nested"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a"), []byte("abc"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "nested", "b"), []byte("12345"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	app := &cli.Command{
+		Action: cmdDU,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "summarize", Aliases: []string{"s"}},
+			&cli.BoolFlag{Name: "human-readable", Aliases: []string{"h"}},
+			&cli.BoolFlag{Name: "bytes", Aliases: []string{"b"}},
+			&cli.IntFlag{Name: "concurrency", Value: 1},
+		},
+	}
+	output := captureStdout(t, func() error {
+		return app.Run(context.Background(), []string{"du", "-s", root})
+	})
+	if !strings.HasSuffix(output, "\t"+root+"\n") {
+		t.Fatalf("unexpected du summary output: %q", output)
+	}
+
+	output = captureStdout(t, func() error {
+		return app.Run(context.Background(), []string{"du", "-h", "-s", root})
+	})
+	if !strings.HasSuffix(output, "\t"+root+"\n") {
+		t.Fatalf("unexpected human-readable du summary output: %q", output)
+	}
+
+	output = captureStdout(t, func() error {
+		return app.Run(context.Background(), []string{"du", "-b", "-s", root})
+	})
+	if !strings.HasSuffix(output, "\t"+root+"\n") {
+		t.Fatalf("unexpected byte du summary output: %q", output)
+	}
+}
+
+func TestDUDefaultPrintsDirectoriesPostOrder(t *testing.T) {
+	root := t.TempDir()
+	sub := filepath.Join(root, "sub")
+	if err := os.Mkdir(sub, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(root, "a"), []byte("abc"), 0o644); err != nil {
+		t.Fatalf("write a: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "b"), []byte("12345"), 0o644); err != nil {
+		t.Fatalf("write b: %v", err)
+	}
+	app := &cli.Command{
+		Action: cmdDU,
+		Flags: []cli.Flag{
+			&cli.BoolFlag{Name: "summarize", Aliases: []string{"s"}},
+			&cli.BoolFlag{Name: "human-readable", Aliases: []string{"h"}},
+			&cli.BoolFlag{Name: "bytes", Aliases: []string{"b"}},
+			&cli.IntFlag{Name: "concurrency", Value: 1},
+		},
+	}
+	output := captureStdout(t, func() error {
+		return app.Run(context.Background(), []string{"du", root})
+	})
+	lines := strings.Split(strings.TrimSpace(output), "\n")
+	if len(lines) != 2 || !strings.HasSuffix(lines[0], "\t"+sub) || !strings.HasSuffix(lines[1], "\t"+root) {
+		t.Fatalf("unexpected du output: %q", output)
+	}
+
+	output = captureStdout(t, func() error {
+		return app.Run(context.Background(), []string{"du", "-b", "-s", root})
+	})
+	if !strings.HasSuffix(output, "\t"+root+"\n") {
+		t.Fatalf("unexpected du byte output: %q", output)
+	}
+}
+
+func TestFormatDiskUsageSize(t *testing.T) {
+	tests := []struct {
+		bytes int64
+		want  string
+	}{
+		{0, "0"},
+		{4 * 1024, "4.0K"},
+		{16 * 1024, "16K"},
+		{3992 * 1024, "3.9M"},
+	}
+	for _, test := range tests {
+		if got := formatDiskUsageSize(test.bytes); got != test.want {
+			t.Errorf("formatDiskUsageSize(%d) = %q, want %q", test.bytes, got, test.want)
+		}
 	}
 }
 

--- a/main_test.go
+++ b/main_test.go
@@ -1118,10 +1118,6 @@ func TestLLRSummaryOnly(t *testing.T) {
 }
 
 func TestDUSummaryIsRecursive(t *testing.T) {
-	originalHelpFlag := cli.HelpFlag
-	cli.HelpFlag = &cli.BoolFlag{Name: "help", Usage: "Show help", HideDefault: true, Local: true}
-	defer func() { cli.HelpFlag = originalHelpFlag }()
-
 	root := t.TempDir()
 	if err := os.Mkdir(filepath.Join(root, "nested"), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
@@ -1136,8 +1132,7 @@ func TestDUSummaryIsRecursive(t *testing.T) {
 		Action: cmdDU,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "summarize", Aliases: []string{"s"}},
-			&cli.BoolFlag{Name: "human-readable", Aliases: []string{"h"}},
-			&cli.BoolFlag{Name: "bytes", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "machine"},
 			&cli.IntFlag{Name: "concurrency", Value: 1},
 		},
 	}
@@ -1149,17 +1144,10 @@ func TestDUSummaryIsRecursive(t *testing.T) {
 	}
 
 	output = captureStdout(t, func() error {
-		return app.Run(context.Background(), []string{"du", "-h", "-s", root})
+		return app.Run(context.Background(), []string{"du", "--machine", "-s", root})
 	})
-	if !strings.HasSuffix(output, "\t"+root+"\n") {
-		t.Fatalf("unexpected human-readable du summary output: %q", output)
-	}
-
-	output = captureStdout(t, func() error {
-		return app.Run(context.Background(), []string{"du", "-b", "-s", root})
-	})
-	if !strings.HasSuffix(output, "\t"+root+"\n") {
-		t.Fatalf("unexpected byte du summary output: %q", output)
+	if output != "8\t"+root+"\n" {
+		t.Fatalf("unexpected machine du summary output: %q", output)
 	}
 }
 
@@ -1179,8 +1167,7 @@ func TestDUDefaultPrintsDirectoriesPostOrder(t *testing.T) {
 		Action: cmdDU,
 		Flags: []cli.Flag{
 			&cli.BoolFlag{Name: "summarize", Aliases: []string{"s"}},
-			&cli.BoolFlag{Name: "human-readable", Aliases: []string{"h"}},
-			&cli.BoolFlag{Name: "bytes", Aliases: []string{"b"}},
+			&cli.BoolFlag{Name: "machine"},
 			&cli.IntFlag{Name: "concurrency", Value: 1},
 		},
 	}
@@ -1193,10 +1180,10 @@ func TestDUDefaultPrintsDirectoriesPostOrder(t *testing.T) {
 	}
 
 	output = captureStdout(t, func() error {
-		return app.Run(context.Background(), []string{"du", "-b", "-s", root})
+		return app.Run(context.Background(), []string{"du", "--machine", "-s", root})
 	})
-	if !strings.HasSuffix(output, "\t"+root+"\n") {
-		t.Fatalf("unexpected du byte output: %q", output)
+	if output != "8\t"+root+"\n" {
+		t.Fatalf("unexpected machine du output: %q", output)
 	}
 }
 
@@ -1206,6 +1193,7 @@ func TestFormatDiskUsageSize(t *testing.T) {
 		want  string
 	}{
 		{0, "0"},
+		{8, "8B"},
 		{4 * 1024, "4.0K"},
 		{16 * 1024, "16K"},
 		{3992 * 1024, "3.9M"},

--- a/progressbar.go
+++ b/progressbar.go
@@ -350,6 +350,15 @@ func (p *progressBar) AddBytes(n int64) {
 	p.bytesDone.Add(n)
 }
 
+func (p *progressBar) SetCountAndBytes(count, bytes int64) {
+	if p == nil {
+		return
+	}
+	atomicMax(&p.done, count)
+	atomicMax(&p.bytesDone, bytes)
+	p.render(p.done.Load())
+}
+
 // atomicMax updates an atomic.Int64 to val if val is greater than the current
 // value. It is safe for concurrent use.
 func atomicMax(a *atomic.Int64, val int64) {

--- a/progressbar.go
+++ b/progressbar.go
@@ -263,6 +263,7 @@ type progressBar struct {
 	lastDone  atomic.Int64
 	lastTotal atomic.Int64
 	finished  atomic.Bool
+	counting  bool // if true, render an indeterminate bar with live item/byte counts
 	pinBottom bool // if true, renders at the bottom of the bar stack
 }
 
@@ -313,6 +314,24 @@ func newStreamingProgressBar(label string, quiet bool, showSpeed bool) *progress
 	bar.lastTotal.Store(progressUninitialized)
 	startElapsedTicker()
 	// total starts at 0; bar won't render until SetTotal(>0) is called.
+	return bar
+}
+
+func newCountingProgressBar(label string, quiet bool) *progressBar {
+	if quiet || !isTerminal(os.Stderr) {
+		return nil
+	}
+	bar := &progressBar{
+		label:     label,
+		width:     28,
+		counting:  true,
+		startedAt: time.Now(),
+	}
+	bar.total.Store(1)
+	bar.lastDone.Store(progressUninitialized)
+	bar.lastTotal.Store(progressUninitialized)
+	startElapsedTicker()
+	bar.render(0)
 	return bar
 }
 
@@ -385,7 +404,9 @@ func (p *progressBar) Finish() {
 		total = 1
 		p.total.Store(total)
 	}
-	p.done.Store(total)
+	if !p.counting {
+		p.done.Store(total)
+	}
 	outputMu.Lock()
 	clearActiveBars()
 	removeActiveBar(p)
@@ -439,8 +460,21 @@ func (p *progressBar) renderAligned(labelWidth int) {
 	if total <= 0 {
 		return
 	}
-	done, total = clampProgress(done, total)
 	elapsedDur := time.Since(p.startedAt)
+	if p.counting {
+		if done < 0 {
+			done = 0
+		}
+		if isTerminal(os.Stderr) {
+			line := formatFancyCountingBar(p.label, done, p.bytesDone.Load(), p.width, elapsedDur, p.finished.Load())
+			fmt.Fprintf(os.Stderr, "\r"+ansiClear+"%s", line)
+		} else {
+			line := formatCountingBar(p.label, done, p.bytesDone.Load(), p.width, elapsedDur, p.finished.Load())
+			fmt.Fprintf(os.Stderr, "\r%s", line)
+		}
+		return
+	}
+	done, total = clampProgress(done, total)
 	elapsed := elapsedDur.Seconds()
 	speed := 0.0
 	if p.showSpeed && elapsed > 0 {
@@ -477,7 +511,13 @@ func (p *progressBar) render(done int64) {
 	if total <= 0 {
 		return
 	}
-	done, total = clampProgress(done, total)
+	if p.counting {
+		if done < 0 {
+			done = 0
+		}
+	} else {
+		done, total = clampProgress(done, total)
+	}
 	if p.lastDone.Load() == done && p.lastTotal.Load() == total {
 		return
 	}
@@ -500,6 +540,42 @@ func (p *progressBar) render(done int64) {
 		return // another goroutine won the race
 	}
 	redrawActiveBars()
+}
+
+func formatCountingBar(label string, count, bytes int64, width int, elapsed time.Duration, complete bool) string {
+	if width < 1 {
+		width = 1
+	}
+	bar := strings.Repeat("=", width)
+	if !complete {
+		position := int(elapsed/(100*time.Millisecond)) % width
+		bar = strings.Repeat(" ", position) + ">" + strings.Repeat(" ", width-position-1)
+	}
+	noun := "files"
+	if count == 1 {
+		noun = "file"
+	}
+	return fmt.Sprintf("%s [%s] %d %s (%s) %s", label, bar, count, noun, formatSize(bytes), formatElapsed(elapsed))
+}
+
+func formatFancyCountingBar(label string, count, bytes int64, width int, elapsed time.Duration, complete bool) string {
+	if width < 1 {
+		width = 1
+	}
+	bar := ansiGreen + strings.Repeat("━", width) + ansiReset
+	suffix := " " + ansiGreen + "✓" + ansiReset
+	if !complete {
+		position := int(elapsed/(100*time.Millisecond)) % width
+		bar = ansiGray + strings.Repeat("━", position) + ansiGreen + "╸" +
+			ansiGray + strings.Repeat("━", width-position-1) + ansiReset
+		suffix = ""
+	}
+	noun := "files"
+	if count == 1 {
+		noun = "file"
+	}
+	return fmt.Sprintf(ansiBold+"%s"+ansiReset+" %s %d %s (%s) %s%s",
+		label, bar, count, noun, formatSize(bytes), formatElapsed(elapsed), suffix)
 }
 
 func formatProgressBar(label string, done, total int64, width int, speed float64, showSpeed bool, byteSized bool, elapsed time.Duration) string {


### PR DESCRIPTION
## Summary
- add `llr -s` / `llr --summary` to print only aggregate file count and total size
- make `du -s` use the same `Listed N files summing to ...` summary and `du --machine -s` use `count<TAB>bytes`
- keep default `du` output human-readable and per-directory
- show an indeterminate TTY progress bar with live count and bytes while scanning
- parallelize Azure summary scans across independent top-level virtual-directory prefixes
- document and test the new behavior

## Performance
On `az://orngnwecresco/data/bolian/capture/` (20,001,477 blobs), the partitioned scanner completed in about 6 minutes. The previous serial scan processed 7.7 million blobs in 8m41s, projecting to roughly 22 minutes for the full folder.

## Testing
- `go test . ./internal/bbbfs`
- `go test ./internal/azblob -run 'Test(SummarizeBlobItems|SummarizePrefixSetAggregatesMonotonicProgress|NormalizeRootPrefix)' -count=1`
- verified `bbb du`, `bbb du -s`, and `bbb du --machine -s` on the nw9 devbox